### PR TITLE
Fix for code editor server targets unable to open workspace folders

### DIFF
--- a/patches/web-server/cdn.diff
+++ b/patches/web-server/cdn.diff
@@ -33,7 +33,7 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/wo
 ===================================================================
 --- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
 +++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
-@@ -582,15 +582,34 @@ function readCookie(name: string): strin
+@@ -594,15 +594,34 @@ function readCookie(name: string): strin
  	return undefined;
  }
  

--- a/patches/web-server/embedding-events.diff
+++ b/patches/web-server/embedding-events.diff
@@ -74,29 +74,17 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/wo
 ===================================================================
 --- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
 +++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
-@@ -472,19 +472,25 @@ class WorkspaceProvider implements IWork
+@@ -472,6 +472,24 @@ class WorkspaceProvider implements IWork
  
  		const targetHref = this.createTargetUrl(workspace, options);
  		if (targetHref) {
--			if (options?.reuse) {
--				mainWindow.location.href = targetHref;
--				return true;
--			} else {
--				let result;
--				if (isStandalone()) {
--					result = mainWindow.open(targetHref, '_blank', 'toolbar=no'); // ensures to open another 'standalone' window!
--				} else {
--					result = mainWindow.open(targetHref);
--				}
-+			var url = new URL(targetHref);
- 
--				return !!result;
-+
++			// post an event to the parent iframe
++			const url = new URL(targetHref);
 +			let target, features;
 +			if (!options?.reuse && isStandalone()) {
 +				target = '_blank';
 +				features = 'toolbar=no';
- 			}
++			}
 +			mainWindow.top?.postMessage({
 +				source: 'code-editor',
 +				action: "openEditor",
@@ -107,10 +95,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/wo
 +				features
 +			}, '*');
 +
-+			return true;
- 		}
- 		return false;
- 	}
++			// try opening a folder in case VS Code is not embedded
+ 			if (options?.reuse) {
+ 				mainWindow.location.href = targetHref;
+ 				return true;
 Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/workbench.ts
 ===================================================================
 --- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/browser/workbench.ts

--- a/patches/web-server/proxy-uri.diff
+++ b/patches/web-server/proxy-uri.diff
@@ -11,7 +11,7 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/wo
  
  interface ISecretStorageCrypto {
  	seal(data: string): Promise<string>;
-@@ -601,6 +602,20 @@ function readCookie(name: string): strin
+@@ -613,6 +614,20 @@ function readCookie(name: string): strin
  		settingsSyncOptions: config.settingsSyncOptions ? { enabled: config.settingsSyncOptions.enabled, } : undefined,
  		workspaceProvider: WorkspaceProvider.create(config),
  		urlCallbackProvider: new LocalStorageURLCallbackProvider(config.callbackRoute),


### PR DESCRIPTION
*Description of changes:*
- The change fixes the broken "Open Folder" command when running Code Editor Server 

*Testing*
<img width="1728" alt="Screenshot 2025-06-03 at 14 13 04" src="https://github.com/user-attachments/assets/15dc12a0-b1e2-41f7-9615-0e9e2ef65018" />

