### PR TITLE
Adding helper script to apply base patches and overrides

### DIFF
--- a/scripts/prepare-src.sh
+++ b/scripts/prepare-src.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+apply_changes() {
+
+    # Use custom path if provided, otherwise default to ./vscode
+    local patched_src_dir="${1:-$(pwd)/vscode}"
+    echo "Creating patched source in directory: ${patched_src_dir}"
+
+    code_editor_module_path="$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
+    patch_dir="${code_editor_module_path}/patches"
+
+    export QUILT_PATCHES="${patch_dir}"
+    export QUILT_SERIES="web-server.series"
+
+    # Clean out the build directory
+    echo "Cleaning build src dir"
+    rm -rf "${patched_src_dir}"
+
+    # Copy third party source
+    rsync -a "${code_editor_module_path}/third-party-src/" "${patched_src_dir}"
+
+    echo "Applying base patches"
+    pushd "${patched_src_dir}"
+    quilt push -a
+    popd
+
+    echo "Applying overrides"
+    rsync -a "${code_editor_module_path}/overrides/" "${patched_src_dir}"
+
+}
+
+custom_path=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --path)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --path requires a value"
+                exit 1
+            fi
+            custom_path="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--path <directory>]"
+            echo "  --path: Custom build directory (default: ./vscode)"
+            exit 0
+            ;;
+        *)
+            echo "Invalid parameter - '$1'"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+apply_changes "${custom_path}"


### PR DESCRIPTION
*Description of changes:*

- Adding script for consumers to create a patched source with overrides.
- The script takes in parameters --path: Custom build directory and defaults to ./vscode if none provided.
- Script cleans the patched source directory, copies the third party source and apply patches and overrides on it.
- Tested by running the command `sh ${PROJ_ROOT}/aws-code-editor/scripts/patch.sh` from a parent directory.
