### PR TITLE
Normalising reference directories and paths in patch hunks

### DIFF
--- a/patches/common/allow-unused-vars.diff
+++ b/patches/common/allow-unused-vars.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/tsconfig.base.json
+Index: third-party-src/src/tsconfig.base.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/tsconfig.base.json
-+++ AWSCodeOSS/build/private/code-editor-src/src/tsconfig.base.json
+--- third-party-src.orig/src/tsconfig.base.json
++++ third-party-src/src/tsconfig.base.json
 @@ -6,7 +6,7 @@
  		"experimentalDecorators": true,
  		"noImplicitReturns": true,
@@ -11,10 +11,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/tsconfig.base.json
  		"noUncheckedSideEffectImports": true,
  		"allowUnreachableCode": false,
  		"strict": true,
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+Index: third-party-src/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+--- third-party-src.orig/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
++++ third-party-src/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
 @@ -30,7 +30,7 @@ export interface IEndpointDetails {
  export class PreferencesSearchService extends Disposable implements IPreferencesSearchService {
  	declare readonly _serviceBrand: undefined;
@@ -24,10 +24,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/prefere
  	private _installedExtensions: Promise<ILocalExtension[]>;
  	private _remoteSearchProvider: IRemoteSearchProvider | undefined;
  	private _aiSearchProvider: IAiSearchProvider | undefined;
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/tunnelView.ts
+Index: third-party-src/src/vs/workbench/contrib/remote/browser/tunnelView.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/tunnelView.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/tunnelView.ts
+--- third-party-src.orig/src/vs/workbench/contrib/remote/browser/tunnelView.ts
++++ third-party-src/src/vs/workbench/contrib/remote/browser/tunnelView.ts
 @@ -762,7 +762,7 @@ export class TunnelPanel extends ViewPan
  	private protocolChangableContextKey: IContextKey<boolean>;
  	private isEditing: boolean = false;

--- a/patches/common/disable-online-services.diff
+++ b/patches/common/disable-online-services.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/update/common/update.config.contribution.ts
+Index: third-party-src/src/vs/platform/update/common/update.config.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/update/common/update.config.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/update/common/update.config.contribution.ts
+--- third-party-src.orig/src/vs/platform/update/common/update.config.contribution.ts
++++ third-party-src/src/vs/platform/update/common/update.config.contribution.ts
 @@ -18,7 +18,7 @@ configurationRegistry.registerConfigurat
  		'update.mode': {
  			type: 'string',
@@ -29,10 +29,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/update/common/up
  			scope: ConfigurationScope.APPLICATION,
  			description: localize('showReleaseNotes', "Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service."),
  			tags: ['usesOnlineServices']
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
+Index: third-party-src/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
++++ third-party-src/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
 @@ -111,7 +111,7 @@ registry.registerConfiguration({
  		'workbench.settings.enableNaturalLanguageSearch': {
  			'type': 'boolean',
@@ -42,10 +42,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/prefere
  			'scope': ConfigurationScope.WINDOW,
  			'tags': ['usesOnlineServices']
  		},
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/assignment/common/assignmentService.ts
+Index: third-party-src/src/vs/workbench/services/assignment/common/assignmentService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/assignment/common/assignmentService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/assignment/common/assignmentService.ts
+--- third-party-src.orig/src/vs/workbench/services/assignment/common/assignmentService.ts
++++ third-party-src/src/vs/workbench/services/assignment/common/assignmentService.ts
 @@ -146,7 +146,7 @@ registry.registerConfiguration({
  		'workbench.enableExperiments': {
  			'type': 'boolean',

--- a/patches/common/disable-telemetry-service.diff
+++ b/patches/common/disable-telemetry-service.diff
@@ -2,10 +2,10 @@ When pulling a new change from upstream, make sure to replace all .data.microsof
 Otherwise the OSS will still ping microsoft, even if the telemetry is set to OFF. 
 See: https://github.com/VSCodium/vscodium/issues/26
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/telemetry/common/telemetryService.ts
+Index: third-party-src/src/vs/platform/telemetry/common/telemetryService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/telemetry/common/telemetryService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/telemetry/common/telemetryService.ts
+--- third-party-src.orig/src/vs/platform/telemetry/common/telemetryService.ts
++++ third-party-src/src/vs/platform/telemetry/common/telemetryService.ts
 @@ -209,7 +209,7 @@ configurationRegistry.registerConfigurat
  	'properties': {
  		[TELEMETRY_SETTING_ID]: {
@@ -33,10 +33,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/telemetry/common
  			'restricted': true,
  			'markdownDeprecationMessage': localize('enableTelemetryDeprecated', "If this setting is false, no telemetry will be sent regardless of the new setting's value. Deprecated in favor of the {0} setting.", `\`#${TELEMETRY_SETTING_ID}#\``),
  			'scope': ConfigurationScope.APPLICATION,
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+Index: third-party-src/src/vs/workbench/electron-sandbox/desktop.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/electron-sandbox/desktop.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+--- third-party-src.orig/src/vs/workbench/electron-sandbox/desktop.contribution.ts
++++ third-party-src/src/vs/workbench/electron-sandbox/desktop.contribution.ts
 @@ -322,7 +322,7 @@ import { registerWorkbenchContribution2,
  			'telemetry.enableCrashReporter': {
  				'type': 'boolean',
@@ -46,10 +46,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/electron-sandbo
  				'tags': ['usesOnlineServices', 'telemetry'],
  				'markdownDeprecationMessage': localize('enableCrashReporterDeprecated', "If this setting is false, no telemetry will be sent regardless of the new setting's value. Deprecated due to being combined into the {0} setting.", `\`#${TELEMETRY_SETTING_ID}#\``),
  			}
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/telemetry/common/1dsAppender.ts
+Index: third-party-src/src/vs/platform/telemetry/common/1dsAppender.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/telemetry/common/1dsAppender.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/telemetry/common/1dsAppender.ts
+--- third-party-src.orig/src/vs/platform/telemetry/common/1dsAppender.ts
++++ third-party-src/src/vs/platform/telemetry/common/1dsAppender.ts
 @@ -19,8 +19,8 @@ export interface IAppInsightsCore {
  	unload(isAsync: boolean, unloadComplete: (unloadState: ITelemetryUnloadState) => void): void;
  }

--- a/patches/common/embedded-api.diff
+++ b/patches/common/embedded-api.diff
@@ -34,10 +34,10 @@ received.
  src/vscode-dts/vscode.d.ts                    |  2 ++
  6 files changed, 47 insertions(+), 1 deletion(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/browser/mainThreadWindow.ts
+Index: third-party-src/src/vs/workbench/api/browser/mainThreadWindow.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/api/browser/mainThreadWindow.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/browser/mainThreadWindow.ts
+--- third-party-src.orig/src/vs/workbench/api/browser/mainThreadWindow.ts
++++ third-party-src/src/vs/workbench/api/browser/mainThreadWindow.ts
 @@ -3,6 +3,7 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
   *--------------------------------------------------------------------------------------------*/
@@ -77,10 +77,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/browser/mai
 +		mainWindow.parent.postMessage(message, origin);
 +	}
  }
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extHost.api.impl.ts
+Index: third-party-src/src/vs/workbench/api/common/extHost.api.impl.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/api/common/extHost.api.impl.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extHost.api.impl.ts
+--- third-party-src.orig/src/vs/workbench/api/common/extHost.api.impl.ts
++++ third-party-src/src/vs/workbench/api/common/extHost.api.impl.ts
 @@ -690,6 +690,14 @@ export function createApiFactoryAndRegis
  
  		// namespace: window
@@ -96,10 +96,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extH
  			get activeTextEditor() {
  				return extHostEditors.getActiveTextEditor();
  			},
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extHost.protocol.ts
+Index: third-party-src/src/vs/workbench/api/common/extHost.protocol.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/api/common/extHost.protocol.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extHost.protocol.ts
+--- third-party-src.orig/src/vs/workbench/api/common/extHost.protocol.ts
++++ third-party-src/src/vs/workbench/api/common/extHost.protocol.ts
 @@ -1744,6 +1744,7 @@ export interface MainThreadWindowShape e
  	$getInitialState(): Promise<{ isFocused: boolean; isActive: boolean }>;
  	$openUri(uri: UriComponents, uriString: string | undefined, options: IOpenUriOptions): Promise<boolean>;
@@ -116,10 +116,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extH
  }
  
  export interface ExtHostLogLevelServiceShape {
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extHostWindow.ts
+Index: third-party-src/src/vs/workbench/api/common/extHostWindow.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/api/common/extHostWindow.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extHostWindow.ts
+--- third-party-src.orig/src/vs/workbench/api/common/extHostWindow.ts
++++ third-party-src/src/vs/workbench/api/common/extHostWindow.ts
 @@ -26,6 +26,7 @@ export class ExtHostWindow implements Ex
  	private _proxy: MainThreadWindowShape;
  
@@ -155,10 +155,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extH
  }
  
  export const IExtHostWindow = createDecorator<IExtHostWindow>('IExtHostWindow');
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensions/common/extensionsProposedApi.ts
+Index: third-party-src/src/vs/workbench/services/extensions/common/extensionsProposedApi.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/extensions/common/extensionsProposedApi.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensions/common/extensionsProposedApi.ts
+--- third-party-src.orig/src/vs/workbench/services/extensions/common/extensionsProposedApi.ts
++++ third-party-src/src/vs/workbench/services/extensions/common/extensionsProposedApi.ts
 @@ -44,7 +44,7 @@ export class ExtensionsProposedApi {
  			for (const [k, value] of Object.entries(productService.extensionEnabledApiProposals)) {
  				const key = ExtensionIdentifier.toKey(k);
@@ -168,10 +168,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extens
  						_logService.warn(`Via 'product.json#extensionEnabledApiProposals' extension '${key}' wants API proposal '${name}' but that proposal DOES NOT EXIST. Likely, the proposal has been finalized (check 'vscode.d.ts') or was abandoned.`);
  						return false;
  					}
-Index: AWSCodeOSS/build/private/code-editor-src/src/vscode-dts/vscode.d.ts
+Index: third-party-src/src/vscode-dts/vscode.d.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vscode-dts/vscode.d.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vscode-dts/vscode.d.ts
+--- third-party-src.orig/src/vscode-dts/vscode.d.ts
++++ third-party-src/src/vscode-dts/vscode.d.ts
 @@ -11000,6 +11000,8 @@ declare module 'vscode' {
  	 * asking for user input.
  	 */

--- a/patches/common/heartbeat.diff
+++ b/patches/common/heartbeat.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
+Index: third-party-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
+--- third-party-src.orig/src/vs/server/node/remoteExtensionHostAgentServer.ts
++++ third-party-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
 @@ -130,6 +130,13 @@ class RemoteExtensionHostAgentServer ext
  			pathname = pathname.substring(this._serverProductPath.length);
  		}

--- a/patches/common/installer.diff
+++ b/patches/common/installer.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.reh.js
+Index: third-party-src/build/gulpfile.reh.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/gulpfile.reh.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/gulpfile.reh.js
+--- third-party-src.orig/build/gulpfile.reh.js
++++ third-party-src/build/gulpfile.reh.js
 @@ -32,6 +32,7 @@ const { vscodeWebResourceIncludes, creat
  const cp = require('child_process');
  const log = require('fancy-log');
@@ -102,20 +102,20 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.reh.js
  
  			const serverTaskCI = task.define(`vscode-${type}${dashed(platform)}${dashed(arch)}${dashed(minified)}-ci`, task.series(
  				compileNativeExtensionsBuildTask,
-Index: AWSCodeOSS/build/private/code-editor-src/build/npm/postinstall.js
+Index: third-party-src/build/npm/postinstall.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/npm/postinstall.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/npm/postinstall.js
+--- third-party-src.orig/build/npm/postinstall.js
++++ third-party-src/build/npm/postinstall.js
 @@ -170,5 +170,3 @@ for (let dir of dirs) {
  	npmInstall(dir, opts);
  }
  
 -cp.execSync('git config pull.rebase merges');
 -cp.execSync('git config blame.ignoreRevsFile .git-blame-ignore-revs');
-Index: AWSCodeOSS/build/private/code-editor-src/build/lib/compilation.js
+Index: third-party-src/build/lib/compilation.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/lib/compilation.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/lib/compilation.js
+--- third-party-src.orig/build/lib/compilation.js
++++ third-party-src/build/lib/compilation.js
 @@ -149,7 +149,7 @@ function compileTask(src, out, build, op
          }
          // mangle: TypeScript to TypeScript
@@ -125,10 +125,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/lib/compilation.js
              let ts2tsMangler = new index_1.Mangler(compile.projectPath, (...data) => (0, fancy_log_1.default)(ansi_colors_1.default.blue('[mangler]'), ...data), { mangleExports: true, manglePrivateFields: true });
              const newContentsByFileName = ts2tsMangler.computeNewFileContents(new Set(['saveState']));
              mangleStream = event_stream_1.default.through(async function write(data) {
-Index: AWSCodeOSS/build/private/code-editor-src/build/lib/dependencies.js
+Index: third-party-src/build/lib/dependencies.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/lib/dependencies.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/lib/dependencies.js
+--- third-party-src.orig/build/lib/dependencies.js
++++ third-party-src/build/lib/dependencies.js
 @@ -24,13 +24,14 @@ function getNpmProductionDependencies(fo
              if (/ELSPROBLEMS/.test(match[0])) {
                  continue;
@@ -146,10 +146,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/lib/dependencies.js
                  throw err;
              }
          }
-Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.extensions.js
+Index: third-party-src/build/gulpfile.extensions.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/gulpfile.extensions.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/gulpfile.extensions.js
+--- third-party-src.orig/build/gulpfile.extensions.js
++++ third-party-src/build/gulpfile.extensions.js
 @@ -102,7 +102,7 @@ const tasks = compilations.map(function
  		headerOut = relativeDirname.substr(index + 1) + '/out';
  	}
@@ -159,10 +159,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.extensions.js
  		const tsb = require('./lib/tsb');
  		const sourcemaps = require('gulp-sourcemaps');
  
-Index: AWSCodeOSS/build/private/code-editor-src/build/lib/optimize.js
+Index: third-party-src/build/lib/optimize.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/lib/optimize.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/lib/optimize.js
+--- third-party-src.orig/build/lib/optimize.js
++++ third-party-src/build/lib/optimize.js
 @@ -144,6 +144,7 @@ function bundleESMTask(opts) {
                  outdir: path_1.default.join(REPO_ROOT_PATH, opts.src),
                  write: false, // enables res.outputFiles
@@ -171,10 +171,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/lib/optimize.js
                  // minify: NOT enabled because we have a separate minify task that takes care of the TSLib banner as well
              }).then(res => {
                  for (const file of res.outputFiles) {
-Index: AWSCodeOSS/build/private/code-editor-src/build/lib/optimize.ts
+Index: third-party-src/build/lib/optimize.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/lib/optimize.ts
-+++ AWSCodeOSS/build/private/code-editor-src/build/lib/optimize.ts
+--- third-party-src.orig/build/lib/optimize.ts
++++ third-party-src/build/lib/optimize.ts
 @@ -145,6 +145,7 @@ function bundleESMTask(opts: IBundleESMT
  				outdir: path.join(REPO_ROOT_PATH, opts.src),
  				write: false, // enables res.outputFiles
@@ -183,10 +183,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/lib/optimize.ts
  				// minify: NOT enabled because we have a separate minify task that takes care of the TSLib banner as well
  			}).then(res => {
  				for (const file of res.outputFiles) {
-Index: AWSCodeOSS/build/private/code-editor-src/build/lib/getVersion.js
+Index: third-party-src/build/lib/getVersion.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/lib/getVersion.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/lib/getVersion.js
+--- third-party-src.orig/build/lib/getVersion.js
++++ third-party-src/build/lib/getVersion.js
 @@ -44,6 +44,6 @@ function getVersion(root) {
      if (!version || !/^[0-9a-f]{40}$/i.test(version.trim())) {
          version = git.getVersion(root);
@@ -196,10 +196,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/lib/getVersion.js
  }
  //# sourceMappingURL=getVersion.js.map
 \ No newline at end of file
-Index: AWSCodeOSS/build/private/code-editor-src/build/lib/getVersion.ts
+Index: third-party-src/build/lib/getVersion.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/lib/getVersion.ts
-+++ AWSCodeOSS/build/private/code-editor-src/build/lib/getVersion.ts
+--- third-party-src.orig/build/lib/getVersion.ts
++++ third-party-src/build/lib/getVersion.ts
 @@ -12,5 +12,5 @@ export function getVersion(root: string)
  		version = git.getVersion(root);
  	}

--- a/patches/common/preapplied/remove-unsafe-headers.diff
+++ b/patches/common/preapplied/remove-unsafe-headers.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/electron-sandbox/workbench/workbench-dev.html
+Index: third-party-src/src/vs/code/electron-sandbox/workbench/workbench-dev.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/electron-sandbox/workbench/workbench-dev.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/electron-sandbox/workbench/workbench-dev.html
+--- third-party-src.orig/src/vs/code/electron-sandbox/workbench/workbench-dev.html
++++ third-party-src/src/vs/code/electron-sandbox/workbench/workbench-dev.html
 @@ -26,7 +26,7 @@
  				;
  				script-src
@@ -11,10 +11,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/electron-sandbox/wor
  					blob:
  					'nonce-0c6a828f1297'
  				;
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/electron-sandbox/workbench/workbench.html
+Index: third-party-src/src/vs/code/electron-sandbox/workbench/workbench.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/electron-sandbox/workbench/workbench.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/electron-sandbox/workbench/workbench.html
+--- third-party-src.orig/src/vs/code/electron-sandbox/workbench/workbench.html
++++ third-party-src/src/vs/code/electron-sandbox/workbench/workbench.html
 @@ -26,7 +26,7 @@
  				;
  				script-src
@@ -24,10 +24,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/electron-sandbox/wor
  					blob:
  				;
  				style-src
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+Index: third-party-src/src/vs/server/node/webClientServer.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+--- third-party-src.orig/src/vs/server/node/webClientServer.ts
++++ third-party-src/src/vs/server/node/webClientServer.ts
 @@ -423,7 +423,7 @@ export class WebClientServer {
  			'default-src \'self\';',
  			'img-src \'self\' https: data: blob:;',
@@ -37,10 +37,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServ
  			'child-src \'self\';',
  			`frame-src 'self' https://*.vscode-cdn.net data:;`,
  			'worker-src \'self\' data: blob:;',
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+Index: third-party-src/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+--- third-party-src.orig/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
++++ third-party-src/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
 @@ -319,7 +319,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
  				${enableCsp ?
  				`<meta http-equiv="Content-Security-Policy" content="
@@ -50,10 +50,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/noteboo
  					style-src ${webviewGenericCspSource} 'unsafe-inline';
  					img-src ${webviewGenericCspSource} https: http: data:;
  					font-src ${webviewGenericCspSource} https:;
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+Index: third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+--- third-party-src.orig/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
++++ third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 @@ -4,7 +4,7 @@
  		<meta http-equiv="Content-Security-Policy" content="
  			default-src 'none';

--- a/patches/common/remove-accounts-feature.diff
+++ b/patches/common/remove-accounts-feature.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/globalCompositeBar.ts
+Index: third-party-src/src/vs/workbench/browser/parts/globalCompositeBar.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/browser/parts/globalCompositeBar.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/globalCompositeBar.ts
+--- third-party-src.orig/src/vs/workbench/browser/parts/globalCompositeBar.ts
++++ third-party-src/src/vs/workbench/browser/parts/globalCompositeBar.ts
 @@ -132,7 +132,7 @@ export class GlobalCompositeBar extends
  	}
  

--- a/patches/common/remove-builtin-extensions.diff
+++ b/patches/common/remove-builtin-extensions.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/product.json
+Index: third-party-src/product.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/product.json
-+++ AWSCodeOSS/build/private/code-editor-src/product.json
+--- third-party-src.orig/product.json
++++ third-party-src/product.json
 @@ -34,54 +34,6 @@
  	"urlProtocol": "code-oss",
  	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",

--- a/patches/common/remove-cloud-changes-feature.diff
+++ b/patches/common/remove-cloud-changes-feature.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/workbench.common.main.ts
+Index: third-party-src/src/vs/workbench/workbench.common.main.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/workbench.common.main.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/workbench.common.main.ts
+--- third-party-src.orig/src/vs/workbench/workbench.common.main.ts
++++ third-party-src/src/vs/workbench/workbench.common.main.ts
 @@ -368,9 +368,6 @@ import './contrib/userDataSync/browser/u
  // User Data Profiles
  import './contrib/userDataProfile/browser/userDataProfile.contribution.js';

--- a/patches/common/remove-disable-prompting-for-non-trusted-urls-option.diff
+++ b/patches/common/remove-disable-prompting-for-non-trusted-urls-option.diff
@@ -5,10 +5,10 @@ Remove option to disable prompting for non-trusted external URLs
  .../contrib/url/browser/url.contribution.ts      | 16 ----------------
  2 files changed, 22 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/url/browser/trustedDomainsValidator.ts
+Index: third-party-src/src/vs/workbench/contrib/url/browser/trustedDomainsValidator.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/url/browser/trustedDomainsValidator.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/url/browser/trustedDomainsValidator.ts
+--- third-party-src.orig/src/vs/workbench/contrib/url/browser/trustedDomainsValidator.ts
++++ third-party-src/src/vs/workbench/contrib/url/browser/trustedDomainsValidator.ts
 @@ -8,7 +8,6 @@ import Severity from '../../../../base/c
  import { URI } from '../../../../base/common/uri.js';
  import { localize } from '../../../../nls.js';
@@ -45,10 +45,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/url/bro
  		const originalResource = resource;
  		let resourceUri: URI;
  		if (typeof resource === 'string') {
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/url/browser/url.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/url/browser/url.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/url/browser/url.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/url/browser/url.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/url/browser/url.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/url/browser/url.contribution.ts
 @@ -18,8 +18,6 @@ import { TrustedDomainsFileSystemProvide
  import { OpenerValidatorContributions } from './trustedDomainsValidator.js';
  import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';

--- a/patches/common/remove-vsda.diff
+++ b/patches/common/remove-vsda.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/sign/browser/signService.ts
+Index: third-party-src/src/vs/platform/sign/browser/signService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/sign/browser/signService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/sign/browser/signService.ts
+--- third-party-src.orig/src/vs/platform/sign/browser/signService.ts
++++ third-party-src/src/vs/platform/sign/browser/signService.ts
 @@ -58,40 +58,12 @@ export class SignService extends Abstrac
  
  	@memoize

--- a/patches/common/suppress-known-errors-script.diff
+++ b/patches/common/suppress-known-errors-script.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/editor/common/errors/suppressedErrors.js
+Index: third-party-src/src/vs/editor/common/errors/suppressedErrors.js
 ===================================================================
 --- /dev/null
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/editor/common/errors/suppressedErrors.js
++++ third-party-src/src/vs/editor/common/errors/suppressedErrors.js
 @@ -0,0 +1,58 @@
 +/**
 + * 

--- a/patches/common/trusted-domains.diff
+++ b/patches/common/trusted-domains.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/url/browser/trustedDomainsFileSystemProvider.ts
+Index: third-party-src/src/vs/workbench/contrib/url/browser/trustedDomainsFileSystemProvider.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/url/browser/trustedDomainsFileSystemProvider.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/url/browser/trustedDomainsFileSystemProvider.ts
+--- third-party-src.orig/src/vs/workbench/contrib/url/browser/trustedDomainsFileSystemProvider.ts
++++ third-party-src/src/vs/workbench/contrib/url/browser/trustedDomainsFileSystemProvider.ts
 @@ -26,14 +26,14 @@ const TRUSTED_DOMAINS_STAT: IStat = {
  
  const CONFIG_HELP_TEXT_PRE = `// Links matching one or more entries in the list below can be opened without link protection.
@@ -48,10 +48,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/url/bro
  	}
  
  	content += CONFIG_HELP_TEXT_AFTER;
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcomeWalkthrough/browser/editor/vs_code_editor_walkthrough.ts
+Index: third-party-src/src/vs/workbench/contrib/welcomeWalkthrough/browser/editor/vs_code_editor_walkthrough.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/welcomeWalkthrough/browser/editor/vs_code_editor_walkthrough.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcomeWalkthrough/browser/editor/vs_code_editor_walkthrough.ts
+--- third-party-src.orig/src/vs/workbench/contrib/welcomeWalkthrough/browser/editor/vs_code_editor_walkthrough.ts
++++ third-party-src/src/vs/workbench/contrib/welcomeWalkthrough/browser/editor/vs_code_editor_walkthrough.ts
 @@ -11,7 +11,7 @@ export default function content(accessor
  	const isServerless = platform.isWeb && !accessor.get(IWorkbenchEnvironmentService).remoteAuthority;
  	return `
@@ -88,10 +88,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcome
  
  
  ## Thanks!
-Index: AWSCodeOSS/build/private/code-editor-src/product.json
+Index: third-party-src/product.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/product.json
-+++ AWSCodeOSS/build/private/code-editor-src/product.json
+--- third-party-src.orig/product.json
++++ third-party-src/product.json
 @@ -82,5 +82,15 @@
  				"publisherDisplayName": "Microsoft"
  			}

--- a/patches/internal/build.diff
+++ b/patches/internal/build.diff
@@ -1,9 +1,9 @@
 Patch that is needed for producing internal builds.
 
-Index: AWSCodeOSS/build/private/code-editor-src/build/lib/mangle/index.ts
+Index: third-party-src/build/lib/mangle/index.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/lib/mangle/index.ts
-+++ AWSCodeOSS/build/private/code-editor-src/build/lib/mangle/index.ts
+--- third-party-src.orig/build/lib/mangle/index.ts
++++ third-party-src/build/lib/mangle/index.ts
 @@ -407,7 +407,7 @@ export class Mangler {
  	) {
  
@@ -13,10 +13,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/lib/mangle/index.ts
  			minWorkers: 'max'
  		});
  	}
-Index: AWSCodeOSS/build/private/code-editor-src/build/lib/mangle/index.js
+Index: third-party-src/build/lib/mangle/index.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/lib/mangle/index.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/lib/mangle/index.js
+--- third-party-src.orig/build/lib/mangle/index.js
++++ third-party-src/build/lib/mangle/index.js
 @@ -354,7 +354,7 @@ class Mangler {
          this.log = log;
          this.config = config;
@@ -26,10 +26,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/lib/mangle/index.js
              minWorkers: 'max'
          });
      }
-Index: AWSCodeOSS/build/private/code-editor-src/build/lib/extensions.js
+Index: third-party-src/build/lib/extensions.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/lib/extensions.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/lib/extensions.js
+--- third-party-src.orig/build/lib/extensions.js
++++ third-party-src/build/lib/extensions.js
 @@ -125,6 +125,21 @@ function fromLocal(extensionPath, forWeb
      }
      return input;
@@ -81,10 +81,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/lib/extensions.js
          .then(fileNames => {
          const files = fileNames
              .map(fileName => path_1.default.join(extensionPath, fileName))
-Index: AWSCodeOSS/build/private/code-editor-src/build/lib/extensions.ts
+Index: third-party-src/build/lib/extensions.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/lib/extensions.ts
-+++ AWSCodeOSS/build/private/code-editor-src/build/lib/extensions.ts
+--- third-party-src.orig/build/lib/extensions.ts
++++ third-party-src/build/lib/extensions.ts
 @@ -89,6 +89,21 @@ function fromLocal(extensionPath: string
  	return input;
  }
@@ -138,10 +138,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/lib/extensions.ts
  		.then(fileNames => {
  			const files = fileNames
  				.map(fileName => path.join(extensionPath, fileName))
-Index: AWSCodeOSS/build/private/code-editor-src/package.json
+Index: third-party-src/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/package.json
+--- third-party-src.orig/package.json
++++ third-party-src/package.json
 @@ -32,7 +32,7 @@
      "watch-extensionsd": "deemon npm run watch-extensions",
      "kill-watch-extensionsd": "deemon --kill npm run watch-extensions",
@@ -200,10 +200,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/package.json
      "@vscode/test-cli": "^0.0.6",
      "@vscode/test-electron": "^2.4.0",
      "@vscode/test-web": "^0.0.62",
-Index: AWSCodeOSS/build/private/code-editor-src/remote/package.json
+Index: third-party-src/remote/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/remote/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/remote/package.json
+--- third-party-src.orig/remote/package.json
++++ third-party-src/remote/package.json
 @@ -5,11 +5,10 @@
    "dependencies": {
      "@microsoft/1ds-core-js": "^3.2.13",
@@ -229,10 +229,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/remote/package.json
      "minimist": "^1.2.6",
      "native-watchdog": "^1.4.1",
      "node-pty": "^1.1.0-beta33",
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/emmet/package.json
+Index: third-party-src/extensions/emmet/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/emmet/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/emmet/package.json
+--- third-party-src.orig/extensions/emmet/package.json
++++ third-party-src/extensions/emmet/package.json
 @@ -482,7 +482,7 @@
      "@types/node": "22.x"
    },
@@ -242,10 +242,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/emmet/package.json
      "@emmetio/html-matcher": "^0.3.3",
      "@emmetio/math-expression": "^1.0.5",
      "@vscode/emmet-helper": "^2.8.8",
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/github/package.json
+Index: third-party-src/extensions/github/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/github/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/github/package.json
+--- third-party-src.orig/extensions/github/package.json
++++ third-party-src/extensions/github/package.json
 @@ -229,7 +229,7 @@
    },
    "dependencies": {
@@ -255,10 +255,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/github/package.json
      "@octokit/rest": "21.1.0",
      "tunnel": "^0.0.6",
      "@vscode/extension-telemetry": "^1.0.0"
-Index: AWSCodeOSS/build/private/code-editor-src/build/package.json
+Index: third-party-src/build/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/build/package.json
+--- third-party-src.orig/build/package.json
++++ third-party-src/build/package.json
 @@ -36,7 +36,6 @@
      "@types/workerpool": "^6.4.0",
      "@types/xml2js": "0.0.33",
@@ -267,10 +267,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/package.json
      "@vscode/vsce": "2.20.1",
      "byline": "^5.0.0",
      "cssnano": "^7.0.7",
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/package.json
+Index: third-party-src/extensions/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/package.json
+--- third-party-src.orig/extensions/package.json
++++ third-party-src/extensions/package.json
 @@ -10,7 +10,7 @@
      "postinstall": "node ./postinstall.mjs"
    },
@@ -280,10 +280,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/package.json
      "esbuild": "0.25.0",
      "vscode-grammar-updater": "^1.1.0"
    },
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/css-language-features/package.json
+Index: third-party-src/extensions/css-language-features/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/css-language-features/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/css-language-features/package.json
+--- third-party-src.orig/extensions/css-language-features/package.json
++++ third-party-src/extensions/css-language-features/package.json
 @@ -994,7 +994,7 @@
      ]
    },
@@ -307,10 +307,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/css-language-features
 +    "vscode-languageserver-textdocument": "1.0.12"
    }
  }
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/html-language-features/package.json
+Index: third-party-src/extensions/html-language-features/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/html-language-features/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/html-language-features/package.json
+--- third-party-src.orig/extensions/html-language-features/package.json
++++ third-party-src/extensions/html-language-features/package.json
 @@ -259,7 +259,7 @@
    },
    "dependencies": {
@@ -334,10 +334,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/html-language-feature
 +    "vscode-languageserver-textdocument": "1.0.12"
    }
  }
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/json-language-features/package.json
+Index: third-party-src/extensions/json-language-features/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/json-language-features/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/json-language-features/package.json
+--- third-party-src.orig/extensions/json-language-features/package.json
++++ third-party-src/extensions/json-language-features/package.json
 @@ -170,7 +170,7 @@
    "dependencies": {
      "@vscode/extension-telemetry": "^0.9.8",
@@ -361,10 +361,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/json-language-feature
 +    "vscode-languageserver-textdocument": "1.0.12"
    }
  }
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/markdown-language-features/package.json
+Index: third-party-src/extensions/markdown-language-features/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/markdown-language-features/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/markdown-language-features/package.json
+--- third-party-src.orig/extensions/markdown-language-features/package.json
++++ third-party-src/extensions/markdown-language-features/package.json
 @@ -771,8 +771,8 @@
      "morphdom": "^2.7.4",
      "picomatch": "^2.3.1",
@@ -397,10 +397,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/markdown-language-fea
 +    "vscode-languageserver-textdocument": "1.0.11"
    }
  }
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/css-language-features/server/package.json
+Index: third-party-src/extensions/css-language-features/server/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/css-language-features/server/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/css-language-features/server/package.json
+--- third-party-src.orig/extensions/css-language-features/server/package.json
++++ third-party-src/extensions/css-language-features/server/package.json
 @@ -12,7 +12,7 @@
    "dependencies": {
      "@vscode/l10n": "^0.0.18",
@@ -424,10 +424,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/css-language-features
 +    "vscode-languageserver-textdocument": "1.0.12"
    }
  }
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/html-language-features/server/package.json
+Index: third-party-src/extensions/html-language-features/server/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/html-language-features/server/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/html-language-features/server/package.json
+--- third-party-src.orig/extensions/html-language-features/server/package.json
++++ third-party-src/extensions/html-language-features/server/package.json
 @@ -12,8 +12,8 @@
      "@vscode/l10n": "^0.0.18",
      "vscode-css-languageservice": "^6.3.6",
@@ -453,10 +453,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/html-language-feature
 +    "vscode-languageserver-textdocument": "1.0.12"
    }
  }
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/json-language-features/server/package.json
+Index: third-party-src/extensions/json-language-features/server/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/json-language-features/server/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/json-language-features/server/package.json
+--- third-party-src.orig/extensions/json-language-features/server/package.json
++++ third-party-src/extensions/json-language-features/server/package.json
 @@ -16,7 +16,7 @@
      "jsonc-parser": "^3.3.1",
      "request-light": "^0.8.0",
@@ -480,10 +480,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/json-language-feature
 +    "vscode-languageserver-textdocument": "1.0.12"
    }
  }
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/css-language-features/server/package-lock.json
+Index: third-party-src/extensions/css-language-features/server/package-lock.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/css-language-features/server/package-lock.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/css-language-features/server/package-lock.json
+--- third-party-src.orig/extensions/css-language-features/server/package-lock.json
++++ third-party-src/extensions/css-language-features/server/package-lock.json
 @@ -93,12 +93,6 @@
          "vscode-languageserver-types": "3.17.6-next.6"
        }
@@ -497,10 +497,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/css-language-features
      "node_modules/vscode-languageserver-textdocument": {
        "version": "1.0.12",
        "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/html-language-features/server/package-lock.json
+Index: third-party-src/extensions/html-language-features/server/package-lock.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/html-language-features/server/package-lock.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/html-language-features/server/package-lock.json
+--- third-party-src.orig/extensions/html-language-features/server/package-lock.json
++++ third-party-src/extensions/html-language-features/server/package-lock.json
 @@ -107,12 +107,6 @@
          "vscode-languageserver-types": "3.17.6-next.6"
        }
@@ -514,10 +514,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/html-language-feature
      "node_modules/vscode-languageserver-textdocument": {
        "version": "1.0.12",
        "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/json-language-features/server/package-lock.json
+Index: third-party-src/extensions/json-language-features/server/package-lock.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/json-language-features/server/package-lock.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/json-language-features/server/package-lock.json
+--- third-party-src.orig/extensions/json-language-features/server/package-lock.json
++++ third-party-src/extensions/json-language-features/server/package-lock.json
 @@ -109,12 +109,6 @@
          "vscode-languageserver-types": "3.17.6-next.6"
        }
@@ -531,10 +531,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/json-language-feature
      "node_modules/vscode-languageserver-textdocument": {
        "version": "1.0.12",
        "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/emmet/package-lock.json
+Index: third-party-src/extensions/emmet/package-lock.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/emmet/package-lock.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/emmet/package-lock.json
+--- third-party-src.orig/extensions/emmet/package-lock.json
++++ third-party-src/extensions/emmet/package-lock.json
 @@ -39,14 +39,6 @@
          "@emmetio/scanner": "^1.0.4"
        }
@@ -550,10 +550,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/emmet/package-lock.js
      "node_modules/@emmetio/html-matcher": {
        "version": "0.3.3",
        "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-0.3.3.tgz",
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/html-language-features/server/src/htmlServer.ts
+Index: third-party-src/extensions/html-language-features/server/src/htmlServer.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/html-language-features/server/src/htmlServer.ts
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/html-language-features/server/src/htmlServer.ts
+--- third-party-src.orig/extensions/html-language-features/server/src/htmlServer.ts
++++ third-party-src/extensions/html-language-features/server/src/htmlServer.ts
 @@ -7,12 +7,11 @@ import {
  	Connection, TextDocuments, InitializeParams, InitializeResult, RequestType,
  	DocumentRangeFormattingRequest, Disposable, ServerCapabilities,

--- a/patches/web-embedded/add-a-much-simpler-workbench.diff
+++ b/patches/web-embedded/add-a-much-simpler-workbench.diff
@@ -7,10 +7,10 @@ workbench HTML file at compile time.
  src/vs/code/browser/workbench/workbench.ts | 634 ++-------------------
  1 file changed, 52 insertions(+), 582 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+Index: third-party-src/src/vs/code/browser/workbench/workbench.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+--- third-party-src.orig/src/vs/code/browser/workbench/workbench.ts
++++ third-party-src/src/vs/code/browser/workbench/workbench.ts
 @@ -3,594 +3,14 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
   *--------------------------------------------------------------------------------------------*/

--- a/patches/web-embedded/add-custom-cache-to-scan-user-extensions-in-reducing-o.diff
+++ b/patches/web-embedded/add-custom-cache-to-scan-user-extensions-in-reducing-o.diff
@@ -4,10 +4,10 @@ Add custom cache to scanUserExtensions in reducing of excessive extension fetch 
  .../browser/webExtensionsScannerService.ts                   | 5 ++++-
  1 file changed, 4 insertions(+), 1 deletion(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
+Index: third-party-src/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
+--- third-party-src.orig/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
++++ third-party-src/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
 @@ -100,6 +100,7 @@ export class WebExtensionsScannerService
  	private readonly customBuiltinExtensionsCacheResource: URI | undefined = undefined;
  	private readonly resourcesAccessQueueMap = new ResourceMap<Queue<IWebExtension[]>>();

--- a/patches/web-embedded/add-default-loader.diff
+++ b/patches/web-embedded/add-default-loader.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.vscode.web.js
+Index: third-party-src/build/gulpfile.vscode.web.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/gulpfile.vscode.web.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/gulpfile.vscode.web.js
+--- third-party-src.orig/build/gulpfile.vscode.web.js
++++ third-party-src/build/gulpfile.vscode.web.js
 @@ -188,6 +188,10 @@ function packageTask(sourceFolderName, d
  			gulp.src('resources/server/code-192.png', { base: 'resources/server' }),
  			gulp.src('resources/server/code-512.png', { base: 'resources/server' })

--- a/patches/web-embedded/clean-up-workbench-and-use-tb-cdn-for-webview-in-pro.diff
+++ b/patches/web-embedded/clean-up-workbench-and-use-tb-cdn-for-webview-in-pro.diff
@@ -4,10 +4,10 @@ Clean up workbench and use TB CDN for webview in prod
  src/vs/code/browser/workbench/workbench.ts | 23 ++++++++++++++--------
  1 file changed, 15 insertions(+), 8 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+Index: third-party-src/src/vs/code/browser/workbench/workbench.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+--- third-party-src.orig/src/vs/code/browser/workbench/workbench.ts
++++ third-party-src/src/vs/code/browser/workbench/workbench.ts
 @@ -592,15 +592,32 @@ function readCookie(name: string): strin
  	return undefined;
  }

--- a/patches/web-embedded/disable-built-in-walkthroughs-from-c.diff
+++ b/patches/web-embedded/disable-built-in-walkthroughs-from-c.diff
@@ -6,10 +6,10 @@ This patch disables the built-in walkthroughs and welcome page functionality in 
  .../common/gettingStartedContent.ts           | 851 +++++++++---------
  2 files changed, 464 insertions(+), 473 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
 @@ -4,15 +4,13 @@
   *--------------------------------------------------------------------------------------------*/
  
@@ -132,10 +132,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcome
  			'description': localize('workbench.startupEditor', "Controls which editor is shown at startup, if none are restored from the previous session.")
  		},
  		'workbench.welcomePage.preferReducedMotion': {
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+Index: third-party-src/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+--- third-party-src.orig/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
++++ third-party-src/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
 @@ -7,14 +7,11 @@ import themePickerContent from './media/
  import themePickerSmallContent from './media/theme_picker_small.js';
  import notebookProfileContent from './media/notebookProfile.js';

--- a/patches/web-embedded/disable-file-actions-calls-accounts-merge-conflit.diff
+++ b/patches/web-embedded/disable-file-actions-calls-accounts-merge-conflit.diff
@@ -15,10 +15,10 @@ This patch disables or modifies various features and functionalities related to 
  .../browser/mergeEditor.contribution.ts       |   4 +-
  11 files changed, 391 insertions(+), 500 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/merge-conflict/package.json
+Index: third-party-src/extensions/merge-conflict/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/merge-conflict/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/merge-conflict/package.json
+--- third-party-src.orig/extensions/merge-conflict/package.json
++++ third-party-src/extensions/merge-conflict/package.json
 @@ -29,80 +29,6 @@
      "watch": "gulp watch-extension:merge-conflict"
    },
@@ -100,10 +100,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/merge-conflict/packag
      "menus": {
        "scm/resourceState/context": [
          {
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/merge-conflict/src/commandHandler.ts
+Index: third-party-src/extensions/merge-conflict/src/commandHandler.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/merge-conflict/src/commandHandler.ts
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/merge-conflict/src/commandHandler.ts
+--- third-party-src.orig/extensions/merge-conflict/src/commandHandler.ts
++++ third-party-src/extensions/merge-conflict/src/commandHandler.ts
 @@ -6,15 +6,6 @@ import * as vscode from 'vscode';
  import * as interfaces from './interfaces';
  import ContentProvider from './contentProvider';
@@ -392,10 +392,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/merge-conflict/src/co
 -		};
 -	}
  }
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/references-view/package.json
+Index: third-party-src/extensions/references-view/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/references-view/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/references-view/package.json
+--- third-party-src.orig/extensions/references-view/package.json
++++ third-party-src/extensions/references-view/package.json
 @@ -121,23 +121,6 @@
          "icon": "$(refresh)"
        },
@@ -449,10 +449,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/references-view/packa
            "command": "references-view.showSupertypes",
            "group": "navigation@1",
            "when": "view == references-view.tree && reference-list.hasResult && reference-list.source == typeHierarchy &&  references-view.typeHierarchyMode != supertypes"
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/references-view/src/calls/index.ts
+Index: third-party-src/extensions/references-view/src/calls/index.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/references-view/src/calls/index.ts
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/references-view/src/calls/index.ts
+--- third-party-src.orig/extensions/references-view/src/calls/index.ts
++++ third-party-src/extensions/references-view/src/calls/index.ts
 @@ -4,40 +4,11 @@
   *--------------------------------------------------------------------------------------------*/
  
@@ -529,10 +529,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/references-view/src/c
 -		this._mem.update(RichCallsDirection._key, value);
 -	}
 -}
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/references-view/src/extension.ts
+Index: third-party-src/extensions/references-view/src/extension.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/references-view/src/extension.ts
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/references-view/src/extension.ts
+--- third-party-src.orig/extensions/references-view/src/extension.ts
++++ third-party-src/extensions/references-view/src/extension.ts
 @@ -4,7 +4,6 @@
   *--------------------------------------------------------------------------------------------*/
  
@@ -549,10 +549,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/references-view/src/e
  	types.register(tree, context);
  
  	function setInput(input: SymbolTreeInput<unknown>) {
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/actions/windowActions.ts
+Index: third-party-src/src/vs/workbench/browser/actions/windowActions.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/browser/actions/windowActions.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/actions/windowActions.ts
+--- third-party-src.orig/src/vs/workbench/browser/actions/windowActions.ts
++++ third-party-src/src/vs/workbench/browser/actions/windowActions.ts
 @@ -7,7 +7,7 @@ import { localize, localize2 } from '../
  import { IWindowOpenable } from '../../../platform/window/common/window.js';
  import { IDialogService } from '../../../platform/dialogs/common/dialogs.js';
@@ -627,10 +627,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/actions
 -	group: '2_open',
 -	order: 4
 -});
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
 @@ -16,7 +16,6 @@ import { SignOutOfAccountAction } from '
  import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
  import { IBrowserWorkbenchEnvironmentService } from '../../../services/environment/browser/environmentService.js';
@@ -647,10 +647,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/authent
  		this._register(registerAction2(ManageAccountPreferencesForExtensionAction));
  		this._register(registerAction2(ManageTrustedMcpServersForAccountAction));
  		this._register(registerAction2(ManageAccountPreferencesForMcpServerAction));
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
 @@ -10,7 +10,7 @@ import { MenuId, MenuRegistry, registerA
  import { ICommandAction } from '../../../../platform/action/common/action.js';
  import { KeyMod, KeyCode } from '../../../../base/common/keyCodes.js';
@@ -715,10 +715,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/files/b
  	group: '5_autosave',
  	command: {
  		id: ToggleAutoSaveAction.ID,
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
+Index: third-party-src/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
+--- third-party-src.orig/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
++++ third-party-src/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
 @@ -14,13 +14,12 @@ import { IDialogService } from '../../..
  import { ITextEditorOptions } from '../../../../../platform/editor/common/editor.js';
  import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -755,10 +755,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/mergeEd
  export class AcceptAllCombination extends MergeEditorAction2 {
  	constructor() {
  		super({
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/mergeEditor/browser/commands/devCommands.ts
+Index: third-party-src/src/vs/workbench/contrib/mergeEditor/browser/commands/devCommands.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/mergeEditor/browser/commands/devCommands.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/mergeEditor/browser/commands/devCommands.ts
+--- third-party-src.orig/src/vs/workbench/contrib/mergeEditor/browser/commands/devCommands.ts
++++ third-party-src/src/vs/workbench/contrib/mergeEditor/browser/commands/devCommands.ts
 @@ -139,7 +139,7 @@ export class MergeEditorLoadContentsFrom
  			category: MERGE_EDITOR_CATEGORY,
  			title: localize2('merge.dev.loadContentsFromFolder', "Load Merge Editor State from Folder"),
@@ -768,10 +768,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/mergeEd
  		});
  	}
  
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
 @@ -15,7 +15,7 @@ import {
  	AcceptAllInput1, AcceptAllInput2, AcceptMerge, CompareInput1WithBaseCommand,
  	CompareInput2WithBaseCommand, GoToNextUnhandledConflict, GoToPreviousUnhandledConflict, OpenBaseFile, OpenMergeEditor,

--- a/patches/web-embedded/disable-user-tasks-and-fix-build-warnings.diff
+++ b/patches/web-embedded/disable-user-tasks-and-fix-build-warnings.diff
@@ -6,10 +6,10 @@ This patch disables user-facing task-related functionality in the codebase.
  .../browser/configurationService.ts           |   1 -
  2 files changed, 159 insertions(+), 167 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
 @@ -50,16 +50,6 @@ import { ITerminalInstance, ITerminalSer
  const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
  workbenchRegistry.registerWorkbenchContribution(RunAutomaticTasks, LifecyclePhase.Eventually);

--- a/patches/web-embedded/dynamic-extension-webworker-init.diff
+++ b/patches/web-embedded/dynamic-extension-webworker-init.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+Index: third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+--- third-party-src.orig/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
++++ third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 @@ -79,8 +79,8 @@
  			if (event.origin !== parentOrigin || event.data.type !== bootstrapNlsType) {
  				return;
@@ -51,10 +51,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extens
  				} else {
  					worker.onerror = console.error.bind(console);
  					window.parent.postMessage({
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/worker/extensionHostWorkerMain.ts
+Index: third-party-src/src/vs/workbench/api/worker/extensionHostWorkerMain.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/api/worker/extensionHostWorkerMain.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/worker/extensionHostWorkerMain.ts
+--- third-party-src.orig/src/vs/workbench/api/worker/extensionHostWorkerMain.ts
++++ third-party-src/src/vs/workbench/api/worker/extensionHostWorkerMain.ts
 @@ -3,7 +3,25 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
   *--------------------------------------------------------------------------------------------*/

--- a/patches/web-embedded/emit-load-time-metrics.diff
+++ b/patches/web-embedded/emit-load-time-metrics.diff
@@ -4,10 +4,10 @@ Emit load time metrics
  src/vs/code/browser/workbench/workbench.ts | 11 +++++++++++
  1 file changed, 11 insertions(+)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+Index: third-party-src/src/vs/code/browser/workbench/workbench.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+--- third-party-src.orig/src/vs/code/browser/workbench/workbench.ts
++++ third-party-src/src/vs/code/browser/workbench/workbench.ts
 @@ -22,6 +22,8 @@ import { AuthenticationSessionInfo } fro
  import type { IURLCallbackProvider } from '../../../workbench/services/url/browser/urlService.js';
  import { create } from '../../../workbench/workbench.web.main.internal.js';

--- a/patches/web-embedded/fix-file-tree-open.diff
+++ b/patches/web-embedded/fix-file-tree-open.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/files/common/explorerModel.ts
+Index: third-party-src/src/vs/workbench/contrib/files/common/explorerModel.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/files/common/explorerModel.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/files/common/explorerModel.ts
+--- third-party-src.orig/src/vs/workbench/contrib/files/common/explorerModel.ts
++++ third-party-src/src/vs/workbench/contrib/files/common/explorerModel.ts
 @@ -92,9 +92,10 @@ export class ExplorerItem {
  
  	public nestedParent: ExplorerItem | undefined;

--- a/patches/web-embedded/fix-watch-target.diff
+++ b/patches/web-embedded/fix-watch-target.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/scripts/code-web.sh
+Index: third-party-src/scripts/code-web.sh
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/scripts/code-web.sh
-+++ AWSCodeOSS/build/private/code-editor-src/scripts/code-web.sh
+--- third-party-src.orig/scripts/code-web.sh
++++ third-party-src/scripts/code-web.sh
 @@ -24,4 +24,9 @@ function code() {
  	$NODE ./scripts/code-web.js "$@"
  }

--- a/patches/web-embedded/only-have-debug-view-container.diff
+++ b/patches/web-embedded/only-have-debug-view-container.diff
@@ -5,10 +5,10 @@ Only have debug view container
  .../contrib/debug/browser/debugCommands.ts    |  39 +-
  2 files changed, 8 insertions(+), 610 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
 @@ -4,447 +4,26 @@
   *--------------------------------------------------------------------------------------------*/
  
@@ -704,10 +704,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/debug/b
 -AccessibleViewRegistry.register(new RunAndDebugAccessibilityHelp());
 -registerWorkbenchContribution2(ReplAccessibilityAnnouncer.ID, ReplAccessibilityAnnouncer, WorkbenchPhase.AfterRestored);
 -registerWorkbenchContribution2(DebugWatchAccessibilityAnnouncer.ID, DebugWatchAccessibilityAnnouncer, WorkbenchPhase.AfterRestored);
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+Index: third-party-src/src/vs/workbench/contrib/debug/browser/debugCommands.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/debug/browser/debugCommands.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+--- third-party-src.orig/src/vs/workbench/contrib/debug/browser/debugCommands.ts
++++ third-party-src/src/vs/workbench/contrib/debug/browser/debugCommands.ts
 @@ -8,11 +8,11 @@ import { KeyCode, KeyMod } from '../../.
  import { List } from '../../../../base/browser/ui/list/listWidget.js';
  import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';

--- a/patches/web-embedded/override-report-issues-with-open-webapp-feedback-com.diff
+++ b/patches/web-embedded/override-report-issues-with-open-webapp-feedback-com.diff
@@ -4,10 +4,10 @@ Override report issues with open webapp feedback command
  .../contrib/issue/common/issue.contribution.ts        | 11 ++---------
  1 file changed, 2 insertions(+), 9 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/issue/common/issue.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/issue/common/issue.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/issue/common/issue.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/issue/common/issue.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/issue/common/issue.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/issue/common/issue.contribution.ts
 @@ -8,7 +8,7 @@ import { localize, localize2 } from '../
  import { ICommandAction } from '../../../../platform/action/common/action.js';
  import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';

--- a/patches/web-embedded/readd-workbench.diff
+++ b/patches/web-embedded/readd-workbench.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.vscode.web.js
+Index: third-party-src/build/gulpfile.vscode.web.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/gulpfile.vscode.web.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/gulpfile.vscode.web.js
+--- third-party-src.orig/build/gulpfile.vscode.web.js
++++ third-party-src/build/gulpfile.vscode.web.js
 @@ -85,6 +85,7 @@ const vscodeWebEntryPoints = [
  	buildfile.workerBackgroundTokenization,
  	buildfile.keyboardMaps,

--- a/patches/web-embedded/remove-chat-actions.diff
+++ b/patches/web-embedded/remove-chat-actions.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
 @@ -714,22 +714,6 @@ registerWorkbenchContribution2(ChatTrans
  registerWorkbenchContribution2(ChatContextContributions.ID, ChatContextContributions, WorkbenchPhase.AfterRestored);
  registerWorkbenchContribution2(ChatResponseResourceFileSystemProvider.ID, ChatResponseResourceFileSystemProvider, WorkbenchPhase.AfterRestored);

--- a/patches/web-embedded/remove-import-export-profiles-and-revert-file-menu-i.diff
+++ b/patches/web-embedded/remove-import-export-profiles-and-revert-file-menu-i.diff
@@ -5,10 +5,10 @@ Remove import/export profiles and revert file menu items in file menu
  .../browser/userDataProfile.ts                | 162 +-----------------
  2 files changed, 4 insertions(+), 203 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
 @@ -10,7 +10,7 @@ import { MenuId, MenuRegistry, registerA
  import { ICommandAction } from '../../../../platform/action/common/action.js';
  import { KeyMod, KeyCode } from '../../../../base/common/keyCodes.js';
@@ -89,10 +89,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/files/b
  
  MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
  	group: '6_close',
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
+Index: third-party-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
+--- third-party-src.orig/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
++++ third-party-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
 @@ -130,8 +130,6 @@ export class UserDataProfilesWorkbenchCo
  		this.registerProfilesActions();
  		this._register(this.userDataProfilesService.onDidChangeProfiles(() => this.registerProfilesActions()));

--- a/patches/web-embedded/remove-menu-entries-for-merge-conflict-and-call-items.diff
+++ b/patches/web-embedded/remove-menu-entries-for-merge-conflict-and-call-items.diff
@@ -8,10 +8,10 @@ This patch remove the context menu entries for merge conflict options and merge 
  .../browser/parts/globalCompositeBar.ts       | 68 +++++++++----------
  4 files changed, 35 insertions(+), 71 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/merge-conflict/package.json
+Index: third-party-src/extensions/merge-conflict/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/merge-conflict/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/merge-conflict/package.json
+--- third-party-src.orig/extensions/merge-conflict/package.json
++++ third-party-src/extensions/merge-conflict/package.json
 @@ -29,32 +29,6 @@
      "watch": "gulp watch-extension:merge-conflict"
    },
@@ -45,10 +45,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/merge-conflict/packag
      "configuration": {
        "title": "%config.title%",
        "properties": {
-Index: AWSCodeOSS/build/private/code-editor-src/extensions/references-view/package.json
+Index: third-party-src/extensions/references-view/package.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/extensions/references-view/package.json
-+++ AWSCodeOSS/build/private/code-editor-src/extensions/references-view/package.json
+--- third-party-src.orig/extensions/references-view/package.json
++++ third-party-src/extensions/references-view/package.json
 @@ -260,16 +260,6 @@
            "when": "view == references-view.tree && viewItem == file-item || view == references-view.tree && viewItem == reference-item"
          },
@@ -66,10 +66,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/extensions/references-view/packa
            "command": "references-view.showSupertypes",
            "group": "1",
            "when": "view == references-view.tree && viewItem == type-item"
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+Index: third-party-src/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+--- third-party-src.orig/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
++++ third-party-src/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
 @@ -257,7 +257,6 @@ export class ActivityBarCompositeBar ext
  		// Global Composite Bar
  		if (this.globalCompositeBar) {

--- a/patches/web-embedded/remove-new-window-actions-and-profile-workspace-section.diff
+++ b/patches/web-embedded/remove-new-window-actions-and-profile-workspace-section.diff
@@ -6,10 +6,10 @@ Remove new window actions and workspace section from profile page
  .../browser/userDataProfilesEditorModel.ts               | 9 ---------
  3 files changed, 12 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
+Index: third-party-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
+--- third-party-src.orig/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
++++ third-party-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
 @@ -126,7 +126,6 @@ export class UserDataProfilesWorkbenchCo
  		this._register(this.registerSwitchProfileAction());
  
@@ -18,10 +18,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/userDat
  		this.registerProfilesActions();
  		this._register(this.userDataProfilesService.onDidChangeProfiles(() => this.registerProfilesActions()));
  
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditor.ts
+Index: third-party-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditor.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditor.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditor.ts
+--- third-party-src.orig/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditor.ts
++++ third-party-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditor.ts
 @@ -758,9 +758,7 @@ class ProfileTreeDataSource implements I
  					children.push({ element: 'name', root: element });
  					children.push({ element: 'icon', root: element });
@@ -32,10 +32,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/userDat
  			}
  			return children;
  		}
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditorModel.ts
+Index: third-party-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditorModel.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditorModel.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditorModel.ts
+--- third-party-src.orig/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditorModel.ts
++++ third-party-src/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditorModel.ts
 @@ -983,17 +983,8 @@ export class UserDataProfilesEditorModel
  			() => this.removeProfile(profileElement.profile)
  		));

--- a/patches/web-embedded/remove-source-control.diff
+++ b/patches/web-embedded/remove-source-control.diff
@@ -5,10 +5,10 @@ This patch removes the entire source control (SCM) feature from CODE OSS as it i
  .../contrib/scm/browser/scm.contribution.ts   | 444 +-----------------
  1 file changed, 1 insertion(+), 443 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
 @@ -3,650 +3,15 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
   *--------------------------------------------------------------------------------------------*/

--- a/patches/web-embedded/remove-ssh-remote-host-in-code-oss.diff
+++ b/patches/web-embedded/remove-ssh-remote-host-in-code-oss.diff
@@ -5,10 +5,10 @@ SSH remote host connections are not supported in the light-weight web version. T
  src/vs/workbench/contrib/remote/browser/remote.contribution.ts | 2 --
  1 file changed, 2 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/remote.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/remote/browser/remote.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/remote.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/remote.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/remote/browser/remote.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/remote/browser/remote.contribution.ts
 @@ -9,7 +9,6 @@ import { ShowCandidateContribution } fro
  import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
  import { TunnelFactoryContribution } from './tunnelFactory.js';

--- a/patches/web-embedded/remove-terminal-in-code-oss.diff
+++ b/patches/web-embedded/remove-terminal-in-code-oss.diff
@@ -5,10 +5,10 @@ This patch removes the entire terminal functionality from Code OSS, including al
  .../terminal/browser/terminal.contribution.ts | 92 +------------------
  1 file changed, 2 insertions(+), 90 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
 @@ -5,9 +5,7 @@
  
  import { getFontSnippets } from '../../../../base/browser/fonts.js';
@@ -140,10 +140,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/termina
 -setupTerminalMenus();
 -
  registerColors();
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/terminalContrib/quickAccess/browser/terminal.quickAccess.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/terminalContrib/quickAccess/browser/terminal.quickAccess.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/terminalContrib/quickAccess/browser/terminal.quickAccess.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/terminalContrib/quickAccess/browser/terminal.quickAccess.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/terminalContrib/quickAccess/browser/terminal.quickAccess.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/terminalContrib/quickAccess/browser/terminal.quickAccess.contribution.ts
 @@ -27,10 +27,6 @@ quickAccessRegistry.registerQuickAccessP
  	placeholder: nls.localize('tasksQuickAccessPlaceholder', "Type the name of a terminal to open."),
  	helpEntries: [{ description: nls.localize('tasksQuickAccessHelp', "Show All Opened Terminals"), commandId: TerminalQuickAccessCommandId.QuickOpenTerm }]

--- a/patches/web-embedded/remove-unsafe-eval-and-unsafe-inline-from-csp-direct.diff
+++ b/patches/web-embedded/remove-unsafe-eval-and-unsafe-inline-from-csp-direct.diff
@@ -7,10 +7,10 @@ Remove unsafe-eval and unsafe-inline from CSP directives
  .../extensions/worker/webWorkerExtensionHostIframe.html     | 2 +-
  4 files changed, 7 insertions(+), 7 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+Index: third-party-src/src/vs/server/node/webClientServer.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+--- third-party-src.orig/src/vs/server/node/webClientServer.ts
++++ third-party-src/src/vs/server/node/webClientServer.ts
 @@ -423,7 +423,7 @@ export class WebClientServer {
  			'default-src \'self\';',
  			'img-src \'self\' https: data: blob:;',
@@ -29,10 +29,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServ
  			'font-src \'self\' blob:;'
  		].join(' ');
  
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+Index: third-party-src/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+--- third-party-src.orig/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
++++ third-party-src/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
 @@ -319,8 +319,8 @@ export class BackLayerWebView<T extends
  				${enableCsp ?
  				`<meta http-equiv="Content-Security-Policy" content="
@@ -44,10 +44,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/noteboo
  					img-src ${webviewGenericCspSource} https: http: data:;
  					font-src ${webviewGenericCspSource} https:;
  					connect-src https:;
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/webview/browser/pre/index.html
+Index: third-party-src/src/vs/workbench/contrib/webview/browser/pre/index.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/webview/browser/pre/index.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/webview/browser/pre/index.html
+--- third-party-src.orig/src/vs/workbench/contrib/webview/browser/pre/index.html
++++ third-party-src/src/vs/workbench/contrib/webview/browser/pre/index.html
 @@ -5,7 +5,7 @@
  	<meta charset="UTF-8">
  
@@ -57,10 +57,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/webview
  
  	<!-- Disable pinch zooming -->
  	<meta name="viewport"
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+Index: third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+--- third-party-src.orig/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
++++ third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 @@ -4,7 +4,7 @@
  		<meta http-equiv="Content-Security-Policy" content="
  			default-src 'none';

--- a/patches/web-embedded/remove-unused-recommended-extensions-action.diff
+++ b/patches/web-embedded/remove-unused-recommended-extensions-action.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+Index: third-party-src/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+--- third-party-src.orig/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
++++ third-party-src/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
 @@ -15,7 +15,7 @@ import { IExtensionIgnoredRecommendation
  import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
  import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';

--- a/patches/web-embedded/revise-help-about-modal-content-and-buttons.diff
+++ b/patches/web-embedded/revise-help-about-modal-content-and-buttons.diff
@@ -6,10 +6,10 @@ Revise Help->About Modal content and buttons
  .../parts/dialogs/dialog.contribution.ts      |  2 +-
  3 files changed, 8 insertions(+), 22 deletions(-)
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/dialogs/dialog.web.contribution.ts
+Index: third-party-src/src/vs/workbench/browser/parts/dialogs/dialog.web.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/browser/parts/dialogs/dialog.web.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/dialogs/dialog.web.contribution.ts
+--- third-party-src.orig/src/vs/workbench/browser/parts/dialogs/dialog.web.contribution.ts
++++ third-party-src/src/vs/workbench/browser/parts/dialogs/dialog.web.contribution.ts
 @@ -34,12 +34,11 @@ export class DialogHandlerContribution e
  		@IKeybindingService keybindingService: IKeybindingService,
  		@IInstantiationService instantiationService: IInstantiationService,
@@ -24,10 +24,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/d
  
  		this.model = (this.dialogService as DialogService).model;
  
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+Index: third-party-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+--- third-party-src.orig/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
++++ third-party-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
 @@ -12,8 +12,6 @@ import { Dialog, IDialogResult } from '.
  import { DisposableStore } from '../../../../base/common/lifecycle.js';
  import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
@@ -84,10 +84,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/d
  	}
  
  	private async doShow(type: Severity | DialogType | undefined, message: string, buttons?: string[], detail?: string, cancelId?: number, checkbox?: ICheckbox, inputs?: IInputElement[], customOptions?: ICustomDialogOptions): Promise<IDialogResult> {
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/electron-sandbox/parts/dialogs/dialog.contribution.ts
+Index: third-party-src/src/vs/workbench/electron-sandbox/parts/dialogs/dialog.contribution.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/electron-sandbox/parts/dialogs/dialog.contribution.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/electron-sandbox/parts/dialogs/dialog.contribution.ts
+--- third-party-src.orig/src/vs/workbench/electron-sandbox/parts/dialogs/dialog.contribution.ts
++++ third-party-src/src/vs/workbench/electron-sandbox/parts/dialogs/dialog.contribution.ts
 @@ -45,7 +45,7 @@ export class DialogHandlerContribution e
  	) {
  		super();

--- a/patches/web-embedded/set-default-log-level-to-error.diff
+++ b/patches/web-embedded/set-default-log-level-to-error.diff
@@ -4,10 +4,10 @@ Set default log level to error
  src/vs/platform/log/common/log.ts | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/log/common/log.ts AWSCodeOSS/build/private/code-editor-src/src/vs/platform/log/common/log.ts
+diff --git third-party-src.orig/src/vs/platform/log/common/log.ts third-party-src/src/vs/platform/log/common/log.ts
 index 28fc419..fa75b46 100644
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/log/common/log.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/log/common/log.ts
+--- third-party-src.orig/src/vs/platform/log/common/log.ts
++++ third-party-src/src/vs/platform/log/common/log.ts
 @@ -38,7 +38,7 @@ export enum LogLevel {
  	Error
  }

--- a/patches/web-embedded/suppress-known-errors-build-integration.diff
+++ b/patches/web-embedded/suppress-known-errors-build-integration.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.vscode.web.js
+Index: third-party-src/build/gulpfile.vscode.web.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/gulpfile.vscode.web.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/gulpfile.vscode.web.js
+--- third-party-src.orig/build/gulpfile.vscode.web.js
++++ third-party-src/build/gulpfile.vscode.web.js
 @@ -56,7 +56,10 @@ const vscodeWebResourceIncludes = [
  	'out-build/vs/editor/common/languages/injections/*.scm',
  

--- a/patches/web-server/base-path.diff
+++ b/patches/web-server/base-path.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/base/common/network.ts
+Index: third-party-src/src/vs/base/common/network.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/base/common/network.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/base/common/network.ts
+--- third-party-src.orig/src/vs/base/common/network.ts
++++ third-party-src/src/vs/base/common/network.ts
 @@ -220,7 +220,9 @@ class RemoteAuthoritiesImpl {
  		return URI.from({
  			scheme: platform.isWeb ? this._preferredWebSchema : Schemas.vscodeRemoteResource,
@@ -13,10 +13,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/base/common/network.ts
  			query
  		});
  	}
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/base/common/product.ts
+Index: third-party-src/src/vs/base/common/product.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/base/common/product.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/base/common/product.ts
+--- third-party-src.orig/src/vs/base/common/product.ts
++++ third-party-src/src/vs/base/common/product.ts
 @@ -56,6 +56,7 @@ export type ExtensionVirtualWorkspaceSup
  };
  
@@ -25,10 +25,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/base/common/product.ts
  	readonly version: string;
  	readonly date?: string;
  	readonly quality?: string;
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench-dev.html
+Index: third-party-src/src/vs/code/browser/workbench/workbench-dev.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench-dev.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench-dev.html
+--- third-party-src.orig/src/vs/code/browser/workbench/workbench-dev.html
++++ third-party-src/src/vs/code/browser/workbench/workbench-dev.html
 @@ -63,7 +63,7 @@
  	</script>
  	<!-- Startup (do not modify order of script tags!) -->
@@ -38,10 +38,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/wo
  		globalThis._VSCODE_FILE_ROOT = baseUrl + '/out/';
  	</script>
  	<script>
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.html
+Index: third-party-src/src/vs/code/browser/workbench/workbench.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.html
+--- third-party-src.orig/src/vs/code/browser/workbench/workbench.html
++++ third-party-src/src/vs/code/browser/workbench/workbench.html
 @@ -60,7 +60,7 @@
  	</script>
  	<!-- Startup (do not modify order of script tags!) -->
@@ -51,10 +51,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/wo
  		globalThis._VSCODE_FILE_ROOT = baseUrl + '/out/';
  	</script>
  	<script>
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+Index: third-party-src/src/vs/code/browser/workbench/workbench.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+--- third-party-src.orig/src/vs/code/browser/workbench/workbench.ts
++++ third-party-src/src/vs/code/browser/workbench/workbench.ts
 @@ -332,7 +332,8 @@ class LocalStorageURLCallbackProvider ex
  			this.startListening();
  		}
@@ -65,10 +65,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/wo
  	}
  
  	private startListening(): void {
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
+Index: third-party-src/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
+--- third-party-src.orig/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
++++ third-party-src/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
 @@ -120,7 +120,7 @@ export abstract class AbstractExtensionR
  					: version,
  				path: 'extension'
@@ -78,10 +78,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/extensionResourc
  		}
  		return undefined;
  	}
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+Index: third-party-src/src/vs/server/node/webClientServer.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+--- third-party-src.orig/src/vs/server/node/webClientServer.ts
++++ third-party-src/src/vs/server/node/webClientServer.ts
 @@ -245,7 +245,10 @@ export class WebClientServer {
  		};
  
@@ -192,10 +192,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServ
 +	const parts = originalUrl.split("?", 1)[0].split("/")
 +	return normalizeUrlPath("./" + parts[parts.length - 1])
 +}
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/serverEnvironmentService.ts
+Index: third-party-src/src/vs/server/node/serverEnvironmentService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/serverEnvironmentService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/serverEnvironmentService.ts
+--- third-party-src.orig/src/vs/server/node/serverEnvironmentService.ts
++++ third-party-src/src/vs/server/node/serverEnvironmentService.ts
 @@ -91,6 +91,9 @@ export const serverOptions: OptionDescri
  
  	'compatibility': { type: 'string' },
@@ -216,10 +216,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/serverEnviron
  	_: string[];
  }
  
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/remote/browser/browserSocketFactory.ts
+Index: third-party-src/src/vs/platform/remote/browser/browserSocketFactory.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/remote/browser/browserSocketFactory.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/remote/browser/browserSocketFactory.ts
+--- third-party-src.orig/src/vs/platform/remote/browser/browserSocketFactory.ts
++++ third-party-src/src/vs/platform/remote/browser/browserSocketFactory.ts
 @@ -281,6 +281,7 @@ export class BrowserSocketFactory implem
  	connect({ host, port }: WebSocketRemoteConnection, path: string, query: string, debugLabel: string): Promise<ISocket> {
  		return new Promise<ISocket>((resolve, reject) => {

--- a/patches/web-server/display-language.diff
+++ b/patches/web-server/display-language.diff
@@ -8,10 +8,10 @@ downloading language packs from a URL configured in the product.json. This patch
 supports language pack extensions and uses files on the remote to set the
 language instead, so it works like the desktop version.
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/serverServices.ts
+Index: third-party-src/src/vs/server/node/serverServices.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/serverServices.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/serverServices.ts
+--- third-party-src.orig/src/vs/server/node/serverServices.ts
++++ third-party-src/src/vs/server/node/serverServices.ts
 @@ -11,7 +11,7 @@ import * as path from '../../base/common
  import { IURITransformer } from '../../base/common/uriIpc.js';
  import { getMachineId, getSqmMachineId, getdevDeviceId } from '../../base/node/id.js';
@@ -31,10 +31,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/serverService
  		// clean up extensions folder
  		remoteExtensionsScanner.whenExtensionsReady().then(() => extensionManagementService.cleanUp());
  
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/environment/common/environmentService.ts
+Index: third-party-src/src/vs/platform/environment/common/environmentService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/environment/common/environmentService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/environment/common/environmentService.ts
+--- third-party-src.orig/src/vs/platform/environment/common/environmentService.ts
++++ third-party-src/src/vs/platform/environment/common/environmentService.ts
 @@ -101,7 +101,7 @@ export abstract class AbstractNativeEnvi
  			return URI.file(join(vscodePortable, 'argv.json'));
  		}
@@ -44,10 +44,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/environment/comm
  	}
  
  	@memoize
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/remoteLanguagePacks.ts
+Index: third-party-src/src/vs/server/node/remoteLanguagePacks.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/remoteLanguagePacks.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/remoteLanguagePacks.ts
+--- third-party-src.orig/src/vs/server/node/remoteLanguagePacks.ts
++++ third-party-src/src/vs/server/node/remoteLanguagePacks.ts
 @@ -3,37 +3,111 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
   *--------------------------------------------------------------------------------------------*/
@@ -177,10 +177,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/remoteLanguag
 +
 +	return nlsFile;
 +}
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+Index: third-party-src/src/vs/server/node/webClientServer.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+--- third-party-src.orig/src/vs/server/node/webClientServer.ts
++++ third-party-src/src/vs/server/node/webClientServer.ts
 @@ -25,6 +25,7 @@ import { URI } from '../../base/common/u
  import { streamToBuffer } from '../../base/common/buffer.js';
  import { IProductConfiguration } from '../../base/common/product.js';
@@ -214,10 +214,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServ
  		}
  
  		const values: { [key: string]: string } = {
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/serverEnvironmentService.ts
+Index: third-party-src/src/vs/server/node/serverEnvironmentService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/serverEnvironmentService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/serverEnvironmentService.ts
+--- third-party-src.orig/src/vs/server/node/serverEnvironmentService.ts
++++ third-party-src/src/vs/server/node/serverEnvironmentService.ts
 @@ -13,6 +13,7 @@ import { memoize } from '../../base/comm
  import { URI } from '../../base/common/uri.js';
  
@@ -234,10 +234,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/serverEnviron
  
  	/* ----- server setup ----- */
  
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/languagePacks/browser/languagePacks.ts
+Index: third-party-src/src/vs/platform/languagePacks/browser/languagePacks.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/languagePacks/browser/languagePacks.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/languagePacks/browser/languagePacks.ts
+--- third-party-src.orig/src/vs/platform/languagePacks/browser/languagePacks.ts
++++ third-party-src/src/vs/platform/languagePacks/browser/languagePacks.ts
 @@ -5,18 +5,24 @@
  
  import { CancellationTokenSource } from '../../../base/common/cancellation.js';
@@ -272,10 +272,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/languagePacks/br
 +		return this.languagePackService.getInstalledLanguages();
  	}
  }
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
+Index: third-party-src/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
+--- third-party-src.orig/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
++++ third-party-src/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
 @@ -51,7 +51,8 @@ class NativeLocaleService implements ILo
  		@IProductService private readonly productService: IProductService
  	) { }
@@ -296,10 +296,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/locali
  		await this.jsonEditingService.write(this.environmentService.argvResource, [{ path: ['locale'], value: locale }], true);
  		return true;
  	}
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+Index: third-party-src/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+--- third-party-src.orig/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
++++ third-party-src/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
 @@ -475,9 +475,6 @@ export class InstallAction extends Exten
  		if (this.extension.isBuiltin) {
  			return;
@@ -363,10 +363,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/extensi
  	}
  
  	override async run(): Promise<any> {
-Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.reh.js
+Index: third-party-src/build/gulpfile.reh.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/gulpfile.reh.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/gulpfile.reh.js
+--- third-party-src.orig/build/gulpfile.reh.js
++++ third-party-src/build/gulpfile.reh.js
 @@ -59,6 +59,7 @@ const serverResourceIncludes = [
  
  	// NLS
@@ -375,10 +375,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.reh.js
  
  	// Process monitor
  	'out-build/vs/base/node/cpuUsage.sh',
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/workbench.web.main.internal.ts
+Index: third-party-src/src/vs/workbench/workbench.web.main.internal.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/workbench.web.main.internal.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/workbench.web.main.internal.ts
+--- third-party-src.orig/src/vs/workbench/workbench.web.main.internal.ts
++++ third-party-src/src/vs/workbench/workbench.web.main.internal.ts
 @@ -53,7 +53,7 @@ import './services/dialogs/browser/fileD
  import './services/host/browser/browserHostService.js';
  import './services/lifecycle/browser/lifecycleService.js';

--- a/patches/web-server/embedding-events.diff
+++ b/patches/web-server/embedding-events.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/remote.ts
+Index: third-party-src/src/vs/workbench/contrib/remote/browser/remote.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/remote.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/remote.ts
+--- third-party-src.orig/src/vs/workbench/contrib/remote/browser/remote.ts
++++ third-party-src/src/vs/workbench/contrib/remote/browser/remote.ts
 @@ -1048,6 +1048,25 @@ export class RemoteAgentConnectionStatus
  						break;
  				}
@@ -28,10 +28,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/remote/
  		}
  	}
  }
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/actions/windowActions.ts
+Index: third-party-src/src/vs/workbench/browser/actions/windowActions.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/browser/actions/windowActions.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/actions/windowActions.ts
+--- third-party-src.orig/src/vs/workbench/browser/actions/windowActions.ts
++++ third-party-src/src/vs/workbench/browser/actions/windowActions.ts
 @@ -410,6 +410,20 @@ class BlurAction extends Action2 {
  	}
  }
@@ -70,10 +70,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/actions
 +window.addEventListener('pagehide', function () {
 +	window.top?.postMessage({source: 'code-editor', action: 'reload'}, '*');
 +});
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+Index: third-party-src/src/vs/code/browser/workbench/workbench.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+--- third-party-src.orig/src/vs/code/browser/workbench/workbench.ts
++++ third-party-src/src/vs/code/browser/workbench/workbench.ts
 @@ -487,6 +487,24 @@ class WorkspaceProvider implements IWork
  
  		const targetHref = this.createTargetUrl(workspace, options);
@@ -99,10 +99,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/wo
  			if (options?.reuse) {
  				mainWindow.location.href = targetHref;
  				return true;
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/workbench.ts
+Index: third-party-src/src/vs/workbench/browser/workbench.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/browser/workbench.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/workbench.ts
+--- third-party-src.orig/src/vs/workbench/browser/workbench.ts
++++ third-party-src/src/vs/workbench/browser/workbench.ts
 @@ -169,6 +169,8 @@ export class Workbench extends Layout {
  		} catch (error) {
  			onUnexpectedError(error);

--- a/patches/web-server/integration.diff
+++ b/patches/web-server/integration.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/product.json
+Index: third-party-src/product.json
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/product.json
-+++ AWSCodeOSS/build/private/code-editor-src/product.json
+--- third-party-src.orig/product.json
++++ third-party-src/product.json
 @@ -1,18 +1,32 @@
  {
 -	"nameShort": "Code - OSS",
@@ -56,10 +56,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/product.json
  	"nodejsRepository": "https://nodejs.org",
  	"urlProtocol": "code-oss",
  	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/product/common/product.ts
+Index: third-party-src/src/vs/platform/product/common/product.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/product/common/product.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/product/common/product.ts
+--- third-party-src.orig/src/vs/platform/product/common/product.ts
++++ third-party-src/src/vs/platform/product/common/product.ts
 @@ -61,8 +61,8 @@ else {
  	if (Object.keys(product).length === 0) {
  		Object.assign(product, {
@@ -71,10 +71,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/product/common/p
  			applicationName: 'code-oss',
  			dataFolderName: '.vscode-oss',
  			urlProtocol: 'code-oss',
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+Index: third-party-src/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+--- third-party-src.orig/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
++++ third-party-src/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
 @@ -872,8 +872,8 @@ export class GettingStartedPage extends
  		}));
  
@@ -86,10 +86,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/welcome
  		);
  
  		const leftColumn = $('.categories-column.categories-column-left', {},);
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/nls.ts
+Index: third-party-src/src/vs/nls.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/nls.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/nls.ts
+--- third-party-src.orig/src/vs/nls.ts
++++ third-party-src/src/vs/nls.ts
 @@ -43,6 +43,7 @@ function _format(message: string, args:
  		// FF3B and FF3D is the Unicode zenkaku representation for [ and ]
  		result = '\uFF3B' + result.replace(/[aouei]/g, '$&$&') + '\uFF3D';
@@ -98,10 +98,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/nls.ts
  
  	return result;
  }
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extHostLocalizationService.ts
+Index: third-party-src/src/vs/workbench/api/common/extHostLocalizationService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/api/common/extHostLocalizationService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extHostLocalizationService.ts
+--- third-party-src.orig/src/vs/workbench/api/common/extHostLocalizationService.ts
++++ third-party-src/src/vs/workbench/api/common/extHostLocalizationService.ts
 @@ -46,7 +46,9 @@ export class ExtHostLocalizationService
  		if (!str) {
  			this.logService.warn(`Using default string since no string found in i18n bundle that has the key: ${key}`);
@@ -113,10 +113,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/api/common/extH
  	}
  
  	getBundle(extensionId: string): { [key: string]: string } | undefined {
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+Index: third-party-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+--- third-party-src.orig/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
++++ third-party-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
 @@ -79,7 +79,7 @@ export class BrowserDialogHandler extend
  	async about(): Promise<void> {
  		const detailString = (useAgo: boolean): string => {
@@ -126,10 +126,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/parts/d
  				this.productService.version || 'Unknown',
  				this.productService.commit || 'Unknown',
  				this.productService.date ? `${this.productService.date}${useAgo ? ' (' + fromNow(new Date(this.productService.date), true) + ')' : ''}` : 'Unknown',
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/workbench.common.main.ts
+Index: third-party-src/src/vs/workbench/workbench.common.main.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/workbench.common.main.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/workbench.common.main.ts
+--- third-party-src.orig/src/vs/workbench/workbench.common.main.ts
++++ third-party-src/src/vs/workbench/workbench.common.main.ts
 @@ -339,7 +339,7 @@ import './contrib/surveys/browser/langua
  
  // Welcome

--- a/patches/web-server/local-storage.diff
+++ b/patches/web-server/local-storage.diff
@@ -16,10 +16,10 @@ To test install the Vim extension and make sure something that uses file storage
 works (history recall for example) and change settings from the UI and on disk
 while making sure they appear on the other side.
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+Index: third-party-src/src/vs/server/node/webClientServer.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+--- third-party-src.orig/src/vs/server/node/webClientServer.ts
++++ third-party-src/src/vs/server/node/webClientServer.ts
 @@ -359,6 +359,7 @@ export class WebClientServer {
  
  		const workbenchWebConfiguration = {
@@ -28,10 +28,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServ
  			serverBasePath: basePath,
  			_wrapWebWorkerExtHostInIframe,
  			developmentOptions: { enableSmokeTestDriver: this._environmentService.args['enable-smoke-test-driver'] ? true : undefined, logLevel: this._logService.getLevel() },
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/web.api.ts
+Index: third-party-src/src/vs/workbench/browser/web.api.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/browser/web.api.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/web.api.ts
+--- third-party-src.orig/src/vs/workbench/browser/web.api.ts
++++ third-party-src/src/vs/workbench/browser/web.api.ts
 @@ -298,6 +298,11 @@ export interface IWorkbenchConstructionO
  	 */
  	readonly configurationDefaults?: Record<string, any>;
@@ -44,10 +44,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/browser/web.api
  	//#endregion
  
  	//#region Profile options
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/environment/browser/environmentService.ts
+Index: third-party-src/src/vs/workbench/services/environment/browser/environmentService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/environment/browser/environmentService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/environment/browser/environmentService.ts
+--- third-party-src.orig/src/vs/workbench/services/environment/browser/environmentService.ts
++++ third-party-src/src/vs/workbench/services/environment/browser/environmentService.ts
 @@ -102,7 +102,14 @@ export class BrowserWorkbenchEnvironment
  	get logFile(): URI { return joinPath(this.windowLogsPath, 'window.log'); }
  

--- a/patches/web-server/marketplace.diff
+++ b/patches/web-server/marketplace.diff
@@ -3,10 +3,10 @@ Adjusted from (MIT licensed) original source:
 
 Add Open VSX as default marketplace
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+Index: third-party-src/src/vs/server/node/webClientServer.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+--- third-party-src.orig/src/vs/server/node/webClientServer.ts
++++ third-party-src/src/vs/server/node/webClientServer.ts
 @@ -338,14 +338,7 @@ export class WebClientServer {
  		const productConfiguration: Partial<Mutable<IProductConfiguration>> = {
  			rootEndpoint: base,
@@ -23,10 +23,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServ
  		};
  
  		const proposedApi = this._environmentService.args['enable-proposed-api'];
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
+Index: third-party-src/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
+--- third-party-src.orig/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
++++ third-party-src/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
 @@ -163,9 +163,9 @@ export abstract class AbstractExtensionR
  	}
  

--- a/patches/web-server/proxy-uri.diff
+++ b/patches/web-server/proxy-uri.diff
@@ -1,8 +1,8 @@
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+Index: third-party-src/src/vs/code/browser/workbench/workbench.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.ts
+--- third-party-src.orig/src/vs/code/browser/workbench/workbench.ts
++++ third-party-src/src/vs/code/browser/workbench/workbench.ts
 @@ -21,6 +21,7 @@ import type { IWorkbenchConstructionOpti
  import { AuthenticationSessionInfo } from '../../../workbench/services/authentication/browser/authenticationService.js';
  import type { IURLCallbackProvider } from '../../../workbench/services/url/browser/urlService.js';
@@ -32,10 +32,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/wo
  		secretStorageProvider: config.remoteAuthority && !secretStorageKeyPath
  			? undefined /* with a remote without embedder-preferred storage, store on the remote */
  			: new LocalStorageSecretStorageProvider(secretStorageCrypto),
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/proxyServer.ts
+Index: third-party-src/src/vs/server/node/proxyServer.ts
 ===================================================================
 --- /dev/null
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/proxyServer.ts
++++ third-party-src/src/vs/server/node/proxyServer.ts
 @@ -0,0 +1,186 @@
 +import proxyServer from "http-proxy";
 +import * as http from "http";
@@ -223,10 +223,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/proxyServer.t
 +		}
 +	}
 +}
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
+Index: third-party-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
+--- third-party-src.orig/src/vs/server/node/remoteExtensionHostAgentServer.ts
++++ third-party-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
 @@ -3,6 +3,8 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
   *--------------------------------------------------------------------------------------------*/
@@ -314,10 +314,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/remoteExtensi
  	/**
  	 * Do not remove!!. Called from server-main.js
  	 */
-Index: AWSCodeOSS/build/private/code-editor-src/src/server-main.ts
+Index: third-party-src/src/server-main.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/server-main.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/server-main.ts
+--- third-party-src.orig/src/server-main.ts
++++ third-party-src/src/server-main.ts
 @@ -96,14 +96,14 @@ if (shouldSpawnCli) {
  		const remoteExtensionHostAgentServer = await getRemoteExtensionHostAgentServer();
  		return remoteExtensionHostAgentServer.handleRequest(req, res);
@@ -335,10 +335,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/server-main.ts
  	});
  	server.on('error', async (err) => {
  		const remoteExtensionHostAgentServer = await getRemoteExtensionHostAgentServer();
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/tunnelFactory.ts
+Index: third-party-src/src/vs/workbench/contrib/remote/browser/tunnelFactory.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/tunnelFactory.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/remote/browser/tunnelFactory.ts
+--- third-party-src.orig/src/vs/workbench/contrib/remote/browser/tunnelFactory.ts
++++ third-party-src/src/vs/workbench/contrib/remote/browser/tunnelFactory.ts
 @@ -4,7 +4,15 @@
   *--------------------------------------------------------------------------------------------*/
  
@@ -586,10 +586,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/remote/
 +		}
 +	}
  }
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/remote/common/tunnelModel.ts
+Index: third-party-src/src/vs/workbench/services/remote/common/tunnelModel.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/remote/common/tunnelModel.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/remote/common/tunnelModel.ts
+--- third-party-src.orig/src/vs/workbench/services/remote/common/tunnelModel.ts
++++ third-party-src/src/vs/workbench/services/remote/common/tunnelModel.ts
 @@ -558,13 +558,7 @@ export class TunnelModel extends Disposa
  	}
  

--- a/patches/web-server/signature-verification.diff
+++ b/patches/web-server/signature-verification.diff
@@ -1,10 +1,10 @@
 Disable extension signature verification that was enabled for Linux in v1.100.
 It does not work since it depends on a closed-source proprietary package - @vscode/vsce-sign and it's not compatible with OpenVSX.
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+Index: third-party-src/src/vs/platform/extensionManagement/node/extensionManagementService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/platform/extensionManagement/node/extensionManagementService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+--- third-party-src.orig/src/vs/platform/extensionManagement/node/extensionManagementService.ts
++++ third-party-src/src/vs/platform/extensionManagement/node/extensionManagementService.ts
 @@ -339,8 +339,7 @@ export class ExtensionManagementService
  
  	private async downloadExtension(extension: IGalleryExtension, operation: InstallOperation, verifySignature: boolean, clientTargetPlatform?: TargetPlatform): Promise<{ readonly location: URI; readonly verificationStatus: ExtensionSignatureVerificationCode | undefined }> {

--- a/patches/web-server/suppress-known-errors-build-integration.diff
+++ b/patches/web-server/suppress-known-errors-build-integration.diff
@@ -1,7 +1,7 @@
-Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.reh.js
+Index: third-party-src/build/gulpfile.reh.js
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/build/gulpfile.reh.js
-+++ AWSCodeOSS/build/private/code-editor-src/build/gulpfile.reh.js
+--- third-party-src.orig/build/gulpfile.reh.js
++++ third-party-src/build/gulpfile.reh.js
 @@ -78,6 +78,8 @@ const serverResourceIncludes = [
  	'out-build/vs/workbench/contrib/terminal/common/scripts/shellIntegration-login.zsh',
  	'out-build/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish',
@@ -11,10 +11,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/build/gulpfile.reh.js
  ];
  
  const serverResourceExcludes = [
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.html
+Index: third-party-src/src/vs/code/browser/workbench/workbench.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench.html
+--- third-party-src.orig/src/vs/code/browser/workbench/workbench.html
++++ third-party-src/src/vs/code/browser/workbench/workbench.html
 @@ -32,6 +32,32 @@
  	<body aria-label="">
  	</body>
@@ -48,10 +48,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/wo
  	<!-- Startup (do not modify order of script tags!) -->
  	<script>
  		const baseUrl = new URL('{{WORKBENCH_WEB_BASE_URL}}', window.location.origin).toString();
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench-dev.html
+Index: third-party-src/src/vs/code/browser/workbench/workbench-dev.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/code/browser/workbench/workbench-dev.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/code/browser/workbench/workbench-dev.html
+--- third-party-src.orig/src/vs/code/browser/workbench/workbench-dev.html
++++ third-party-src/src/vs/code/browser/workbench/workbench-dev.html
 @@ -35,6 +35,32 @@
  	<body aria-label="">
  	</body>

--- a/patches/web-server/webview.diff
+++ b/patches/web-server/webview.diff
@@ -40,10 +40,10 @@ check.
 Note: webviews will only work in secure contexts (i.e. accessing the server using https or localhost)
 And this change will not apply if using port forwarding to access the server from a different address
 
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/environment/browser/environmentService.ts
+Index: third-party-src/src/vs/workbench/services/environment/browser/environmentService.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/environment/browser/environmentService.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/environment/browser/environmentService.ts
+--- third-party-src.orig/src/vs/workbench/services/environment/browser/environmentService.ts
++++ third-party-src/src/vs/workbench/services/environment/browser/environmentService.ts
 @@ -227,7 +227,7 @@ export class BrowserWorkbenchEnvironment
  
  	@memoize
@@ -53,10 +53,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/enviro
  			|| this.productService.webviewContentExternalBaseUrlTemplate
  			|| 'https://{{uuid}}.vscode-cdn.net/{{quality}}/{{commit}}/out/vs/workbench/contrib/webview/browser/pre/';
  
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+Index: third-party-src/src/vs/server/node/webClientServer.ts
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServer.ts
+--- third-party-src.orig/src/vs/server/node/webClientServer.ts
++++ third-party-src/src/vs/server/node/webClientServer.ts
 @@ -364,6 +364,7 @@ export class WebClientServer {
  		const workbenchWebConfiguration = {
  			remoteAuthority,
@@ -65,10 +65,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/server/node/webClientServ
  			serverBasePath: this._basePath,
  			_wrapWebWorkerExtHostInIframe,
  			developmentOptions: { enableSmokeTestDriver: this._environmentService.args['enable-smoke-test-driver'] ? true : undefined, logLevel: this._logService.getLevel() },
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/webview/browser/pre/index.html
+Index: third-party-src/src/vs/workbench/contrib/webview/browser/pre/index.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/contrib/webview/browser/pre/index.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/webview/browser/pre/index.html
+--- third-party-src.orig/src/vs/workbench/contrib/webview/browser/pre/index.html
++++ third-party-src/src/vs/workbench/contrib/webview/browser/pre/index.html
 @@ -351,6 +351,12 @@
  
  				const hostname = location.hostname;
@@ -82,10 +82,10 @@ Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/contrib/webview
  				if (!crypto.subtle) {
  					// cannot validate, not running in a secure context
  					throw new Error(`'crypto.subtle' is not available so webviews will not work. This is likely because the editor is not running in a secure context (https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).`);
-Index: AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+Index: third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 ===================================================================
---- AWSCodeOSS.orig/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
-+++ AWSCodeOSS/build/private/code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+--- third-party-src.orig/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
++++ third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 @@ -25,6 +25,13 @@
  			// validation not requested
  			return start();


### PR DESCRIPTION
*Description of changes:*

- Updating the reference directories and relative paths present in patch hunks for all patches in aws/code-editor.
- The patch script pushed in PR: https://github.com/aws/code-editor/pull/11 already assumes this relative path while patching the source code.