### PR TITLE
Update patches and overrides for 1.101.x

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -3722,7 +3722,7 @@ SOFTWARE.
 ******************************
 
 @parcel/watcher
-2.5.0 <https://github.com/parcel-bundler/watcher>
+2.5.1 <https://github.com/parcel-bundler/watcher>
 MIT License
 
 Copyright (c) 2017-present Devon Govett
@@ -3749,7 +3749,7 @@ SOFTWARE.
 ******************************
 
 @parcel/watcher-linux-x64-glibc
-2.5.0 <https://github.com/parcel-bundler/watcher>
+2.5.1 <https://github.com/parcel-bundler/watcher>
 MIT License
 
 Copyright (c) 2017-present Devon Govett
@@ -3776,7 +3776,7 @@ SOFTWARE.
 ******************************
 
 @parcel/watcher-linux-x64-musl
-2.5.0 <https://github.com/parcel-bundler/watcher>
+2.5.1 <https://github.com/parcel-bundler/watcher>
 MIT License
 
 Copyright (c) 2017-present Devon Govett

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -3722,7 +3722,7 @@ SOFTWARE.
 ******************************
 
 @parcel/watcher
-2.5.0 <https://github.com/parcel-bundler/watcher>
+2.5.1 <https://github.com/parcel-bundler/watcher>
 MIT License
 
 Copyright (c) 2017-present Devon Govett
@@ -3749,7 +3749,7 @@ SOFTWARE.
 ******************************
 
 @parcel/watcher-linux-x64-glibc
-2.5.0 <https://github.com/parcel-bundler/watcher>
+2.5.1 <https://github.com/parcel-bundler/watcher>
 MIT License
 
 Copyright (c) 2017-present Devon Govett
@@ -3776,7 +3776,7 @@ SOFTWARE.
 ******************************
 
 @parcel/watcher-linux-x64-musl
-2.5.0 <https://github.com/parcel-bundler/watcher>
+2.5.1 <https://github.com/parcel-bundler/watcher>
 MIT License
 
 Copyright (c) 2017-present Devon Govett

--- a/patches/common/trusted-domains.diff
+++ b/patches/common/trusted-domains.diff
@@ -105,6 +105,6 @@ Index: third-party-src/product.json
 +		"https://console.aws.amazon.com",
 +		"https://console.amazonaws-us-gov.com",
 +		"https://console.amazonaws.cn",
-+		"https://aws.amazon.com*"
++		"https://aws.amazon.com"
  	]
  }

--- a/patches/internal/build.diff
+++ b/patches/internal/build.diff
@@ -151,14 +151,7 @@ Index: third-party-src/package.json
      "electron": "node build/lib/electron",
      "7z": "7z",
      "update-grammars": "node build/npm/update-all-grammars.mjs",
-@@ -71,13 +71,12 @@
-   "dependencies": {
-     "@microsoft/1ds-core-js": "^3.2.13",
-     "@microsoft/1ds-post-js": "^3.2.13",
--    "@parcel/watcher": "2.5.1",
-+    "@parcel/watcher": "2.5.0",
-     "@types/semver": "^7.5.8",
-     "@vscode/deviceid": "^0.1.1",
+@@ -77,7 +77,6 @@
      "@vscode/iconv-lite-umd": "0.7.0",
      "@vscode/policy-watcher": "^1.3.2",
      "@vscode/proxy-agent": "^0.32.0",
@@ -166,11 +159,7 @@ Index: third-party-src/package.json
      "@vscode/spdlog": "^0.15.2",
      "@vscode/sqlite3": "5.1.8-vscode",
      "@vscode/sudo-prompt": "9.3.1",
-@@ -96,15 +95,14 @@
-     "@xterm/addon-webgl": "^0.19.0-beta.107",
-     "@xterm/headless": "^5.6.0-beta.107",
-     "@xterm/xterm": "^5.6.0-beta.107",
-+    "http-proxy": "^1.18.1",
+@@ -100,10 +99,8 @@
      "http-proxy-agent": "^7.0.0",
      "https-proxy-agent": "^7.0.2",
      "jschardet": "3.1.4",
@@ -179,20 +168,9 @@ Index: third-party-src/package.json
      "native-is-elevated": "0.7.0",
 -    "native-keymap": "^3.3.5",
      "native-watchdog": "^1.4.1",
--    "node-pty": "^1.1.0-beta33",
-+    "node-pty": "1.1.0-beta33",
+     "node-pty": "^1.1.0-beta33",
      "open": "^8.4.2",
-     "tas-client-umd": "0.2.0",
-     "v8-inspect-profiler": "^0.1.1",
-@@ -121,6 +119,7 @@
-     "@types/debug": "^4.1.5",
-     "@types/eslint": "^9.6.1",
-     "@types/gulp-svgmin": "^1.2.1",
-+    "@types/http-proxy": "^1.17.15",
-     "@types/http-proxy-agent": "^2.0.1",
-     "@types/kerberos": "^1.1.2",
-     "@types/minimist": "^1.2.1",
-@@ -139,7 +138,6 @@
+@@ -141,7 +138,6 @@
      "@typescript-eslint/utils": "^8.8.0",
      "@vscode/gulp-electron": "^1.36.0",
      "@vscode/l10n-dev": "0.0.35",
@@ -204,12 +182,7 @@ Index: third-party-src/remote/package.json
 ===================================================================
 --- third-party-src.orig/remote/package.json
 +++ third-party-src/remote/package.json
-@@ -5,11 +5,10 @@
-   "dependencies": {
-     "@microsoft/1ds-core-js": "^3.2.13",
-     "@microsoft/1ds-post-js": "^3.2.13",
--    "@parcel/watcher": "2.5.1",
-+    "@parcel/watcher": "2.5.0",
+@@ -9,7 +9,6 @@
      "@vscode/deviceid": "^0.1.1",
      "@vscode/iconv-lite-umd": "0.7.0",
      "@vscode/proxy-agent": "^0.32.0",
@@ -217,11 +190,7 @@ Index: third-party-src/remote/package.json
      "@vscode/spdlog": "^0.15.2",
      "@vscode/tree-sitter-wasm": "^0.1.4",
      "@vscode/vscode-languagedetection": "1.0.21",
-@@ -26,10 +25,10 @@
-     "@xterm/headless": "^5.6.0-beta.107",
-     "@xterm/xterm": "^5.6.0-beta.107",
-     "cookie": "^0.7.0",
-+    "http-proxy": "^1.18.1",
+@@ -30,7 +29,6 @@
      "http-proxy-agent": "^7.0.0",
      "https-proxy-agent": "^7.0.2",
      "jschardet": "3.1.4",
@@ -229,32 +198,6 @@ Index: third-party-src/remote/package.json
      "minimist": "^1.2.6",
      "native-watchdog": "^1.4.1",
      "node-pty": "^1.1.0-beta33",
-Index: third-party-src/extensions/emmet/package.json
-===================================================================
---- third-party-src.orig/extensions/emmet/package.json
-+++ third-party-src/extensions/emmet/package.json
-@@ -482,7 +482,7 @@
-     "@types/node": "22.x"
-   },
-   "dependencies": {
--    "@emmetio/css-parser": "ramya-rao-a/css-parser#vscode",
-+    "@emmetio/css-parser": "0.4.0",
-     "@emmetio/html-matcher": "^0.3.3",
-     "@emmetio/math-expression": "^1.0.5",
-     "@vscode/emmet-helper": "^2.8.8",
-Index: third-party-src/extensions/github/package.json
-===================================================================
---- third-party-src.orig/extensions/github/package.json
-+++ third-party-src/extensions/github/package.json
-@@ -229,7 +229,7 @@
-   },
-   "dependencies": {
-     "@octokit/graphql": "8.2.0",
--    "@octokit/graphql-schema": "14.4.0",
-+    "@octokit/graphql-schema": "14.58.0",
-     "@octokit/rest": "21.1.0",
-     "tunnel": "^0.0.6",
-     "@vscode/extension-telemetry": "^1.0.0"
 Index: third-party-src/build/package.json
 ===================================================================
 --- third-party-src.orig/build/package.json
@@ -267,334 +210,3 @@ Index: third-party-src/build/package.json
      "@vscode/vsce": "2.20.1",
      "byline": "^5.0.0",
      "cssnano": "^7.0.7",
-Index: third-party-src/extensions/package.json
-===================================================================
---- third-party-src.orig/extensions/package.json
-+++ third-party-src/extensions/package.json
-@@ -10,7 +10,7 @@
-     "postinstall": "node ./postinstall.mjs"
-   },
-   "devDependencies": {
--    "@parcel/watcher": "2.5.1",
-+    "@parcel/watcher": "2.5.0",
-     "esbuild": "0.25.0",
-     "vscode-grammar-updater": "^1.1.0"
-   },
-Index: third-party-src/extensions/css-language-features/package.json
-===================================================================
---- third-party-src.orig/extensions/css-language-features/package.json
-+++ third-party-src/extensions/css-language-features/package.json
-@@ -994,7 +994,7 @@
-     ]
-   },
-   "dependencies": {
--    "vscode-languageclient": "^10.0.0-next.15",
-+    "vscode-languageclient": "10.0.0-next.9",
-     "vscode-uri": "^3.1.0"
-   },
-   "devDependencies": {
-@@ -1003,5 +1003,13 @@
-   "repository": {
-     "type": "git",
-     "url": "https://github.com/microsoft/vscode.git"
-+  },
-+  "overrides": {
-+    "vscode-jsonrpc": "9.0.0-next.5",
-+    "vscode-languageclient": "10.0.0-next.9",
-+    "vscode-languageserver-types": "3.17.5",
-+    "vscode-languageserver": "10.0.0-next.7",
-+    "vscode-languageserver-protocol": "3.17.6-next.7",
-+    "vscode-languageserver-textdocument": "1.0.12"
-   }
- }
-Index: third-party-src/extensions/html-language-features/package.json
-===================================================================
---- third-party-src.orig/extensions/html-language-features/package.json
-+++ third-party-src/extensions/html-language-features/package.json
-@@ -259,7 +259,7 @@
-   },
-   "dependencies": {
-     "@vscode/extension-telemetry": "^0.9.8",
--    "vscode-languageclient": "^10.0.0-next.15",
-+    "vscode-languageclient": "10.0.0-next.9",
-     "vscode-uri": "^3.1.0"
-   },
-   "devDependencies": {
-@@ -268,5 +268,13 @@
-   "repository": {
-     "type": "git",
-     "url": "https://github.com/microsoft/vscode.git"
-+  },
-+  "overrides": {
-+    "vscode-jsonrpc": "9.0.0-next.5",
-+    "vscode-languageclient": "10.0.0-next.9",
-+    "vscode-languageserver-types": "3.17.5",
-+    "vscode-languageserver": "10.0.0-next.7",
-+    "vscode-languageserver-protocol": "3.17.6-next.7",
-+    "vscode-languageserver-textdocument": "1.0.12"
-   }
- }
-Index: third-party-src/extensions/json-language-features/package.json
-===================================================================
---- third-party-src.orig/extensions/json-language-features/package.json
-+++ third-party-src/extensions/json-language-features/package.json
-@@ -170,7 +170,7 @@
-   "dependencies": {
-     "@vscode/extension-telemetry": "^0.9.8",
-     "request-light": "^0.8.0",
--    "vscode-languageclient": "^10.0.0-next.15"
-+    "vscode-languageclient": "10.0.0-next.9"
-   },
-   "devDependencies": {
-     "@types/node": "22.x"
-@@ -178,5 +178,13 @@
-   "repository": {
-     "type": "git",
-     "url": "https://github.com/microsoft/vscode.git"
-+  },
-+  "overrides": {
-+    "vscode-jsonrpc": "9.0.0-next.5",
-+    "vscode-languageclient": "10.0.0-next.9",
-+    "vscode-languageserver-types": "3.17.5",
-+    "vscode-languageserver": "10.0.0-next.7",
-+    "vscode-languageserver-protocol": "3.17.6-next.7",
-+    "vscode-languageserver-textdocument": "1.0.12"
-   }
- }
-Index: third-party-src/extensions/markdown-language-features/package.json
-===================================================================
---- third-party-src.orig/extensions/markdown-language-features/package.json
-+++ third-party-src/extensions/markdown-language-features/package.json
-@@ -771,8 +771,8 @@
-     "morphdom": "^2.7.4",
-     "picomatch": "^2.3.1",
-     "punycode": "^2.3.1",
--    "vscode-languageclient": "^8.0.2",
--    "vscode-languageserver-textdocument": "^1.0.11",
-+    "vscode-languageclient": "9.0.1",
-+    "vscode-languageserver-textdocument": "1.0.11",
-     "vscode-markdown-languageserver": "^0.5.0-alpha.11",
-     "vscode-uri": "^3.0.3"
-   },
-@@ -785,11 +785,19 @@
-     "@types/vscode-webview": "^1.57.0",
-     "@vscode/markdown-it-katex": "^1.1.1",
-     "lodash.throttle": "^4.1.1",
--    "vscode-languageserver-types": "^3.17.2",
-+    "vscode-languageserver-types": "3.17.5",
-     "vscode-markdown-languageservice": "^0.3.0-alpha.3"
-   },
-   "repository": {
-     "type": "git",
-     "url": "https://github.com/microsoft/vscode.git"
-+  },
-+  "overrides": {
-+    "vscode-jsonrpc": "8.2.0",
-+    "vscode-languageclient": "9.0.1",
-+    "vscode-languageserver-types": "3.17.5",
-+    "vscode-languageserver": "9.0.1",
-+    "vscode-languageserver-protocol": "3.17.5",
-+    "vscode-languageserver-textdocument": "1.0.11"
-   }
- }
-Index: third-party-src/extensions/css-language-features/server/package.json
-===================================================================
---- third-party-src.orig/extensions/css-language-features/server/package.json
-+++ third-party-src/extensions/css-language-features/server/package.json
-@@ -12,7 +12,7 @@
-   "dependencies": {
-     "@vscode/l10n": "^0.0.18",
-     "vscode-css-languageservice": "^6.3.6",
--    "vscode-languageserver": "^10.0.0-next.13",
-+    "vscode-languageserver": "10.0.0-next.7",
-     "vscode-uri": "^3.1.0"
-   },
-   "devDependencies": {
-@@ -27,5 +27,13 @@
-     "install-server-next": "npm install vscode-languageserver@next",
-     "install-server-local": "npm install vscode-languageserver",
-     "test": "node ./test/index.js"
-+  },
-+  "overrides": {
-+    "vscode-jsonrpc": "9.0.0-next.5",
-+    "vscode-languageclient": "10.0.0-next.9",
-+    "vscode-languageserver-types": "3.17.5",
-+    "vscode-languageserver": "10.0.0-next.7",
-+    "vscode-languageserver-protocol": "3.17.6-next.7",
-+    "vscode-languageserver-textdocument": "1.0.12"
-   }
- }
-Index: third-party-src/extensions/html-language-features/server/package.json
-===================================================================
---- third-party-src.orig/extensions/html-language-features/server/package.json
-+++ third-party-src/extensions/html-language-features/server/package.json
-@@ -12,8 +12,8 @@
-     "@vscode/l10n": "^0.0.18",
-     "vscode-css-languageservice": "^6.3.6",
-     "vscode-html-languageservice": "^5.5.0",
--    "vscode-languageserver": "^10.0.0-next.13",
--    "vscode-languageserver-textdocument": "^1.0.12",
-+    "vscode-languageserver": "10.0.0-next.7",
-+    "vscode-languageserver-textdocument": "1.0.12",
-     "vscode-uri": "^3.1.0"
-   },
-   "devDependencies": {
-@@ -28,5 +28,13 @@
-     "install-server-next": "npm install vscode-languageserver@next",
-     "install-server-local": "npm install vscode-languageserver",
-     "test": "npm run compile && node ./test/index.js"
-+  },
-+  "overrides": {
-+    "vscode-jsonrpc": "9.0.0-next.5",
-+    "vscode-languageclient": "10.0.0-next.9",
-+    "vscode-languageserver-types": "3.17.5",
-+    "vscode-languageserver": "10.0.0-next.7",
-+    "vscode-languageserver-protocol": "3.17.6-next.7",
-+    "vscode-languageserver-textdocument": "1.0.12"
-   }
- }
-Index: third-party-src/extensions/json-language-features/server/package.json
-===================================================================
---- third-party-src.orig/extensions/json-language-features/server/package.json
-+++ third-party-src/extensions/json-language-features/server/package.json
-@@ -16,7 +16,7 @@
-     "jsonc-parser": "^3.3.1",
-     "request-light": "^0.8.0",
-     "vscode-json-languageservice": "^5.6.0",
--    "vscode-languageserver": "^10.0.0-next.13",
-+    "vscode-languageserver": "10.0.0-next.7",
-     "vscode-uri": "^3.1.0"
-   },
-   "devDependencies": {
-@@ -34,5 +34,13 @@
-     "install-server-next": "npm install vscode-languageserver@next",
-     "install-server-local": "npm link vscode-languageserver-server",
-     "version": "git commit -m \"JSON Language Server $npm_package_version\" package.json"
-+  },
-+  "overrides": {
-+    "vscode-jsonrpc": "9.0.0-next.5",
-+    "vscode-languageclient": "10.0.0-next.9",
-+    "vscode-languageserver-types": "3.17.5",
-+    "vscode-languageserver": "10.0.0-next.7",
-+    "vscode-languageserver-protocol": "3.17.6-next.7",
-+    "vscode-languageserver-textdocument": "1.0.12"
-   }
- }
-Index: third-party-src/extensions/css-language-features/server/package-lock.json
-===================================================================
---- third-party-src.orig/extensions/css-language-features/server/package-lock.json
-+++ third-party-src/extensions/css-language-features/server/package-lock.json
-@@ -93,12 +93,6 @@
-         "vscode-languageserver-types": "3.17.6-next.6"
-       }
-     },
--    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
--      "version": "3.17.6-next.6",
--      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.6.tgz",
--      "integrity": "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ==",
--      "license": "MIT"
--    },
-     "node_modules/vscode-languageserver-textdocument": {
-       "version": "1.0.12",
-       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-Index: third-party-src/extensions/html-language-features/server/package-lock.json
-===================================================================
---- third-party-src.orig/extensions/html-language-features/server/package-lock.json
-+++ third-party-src/extensions/html-language-features/server/package-lock.json
-@@ -107,12 +107,6 @@
-         "vscode-languageserver-types": "3.17.6-next.6"
-       }
-     },
--    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
--      "version": "3.17.6-next.6",
--      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.6.tgz",
--      "integrity": "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ==",
--      "license": "MIT"
--    },
-     "node_modules/vscode-languageserver-textdocument": {
-       "version": "1.0.12",
-       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-Index: third-party-src/extensions/json-language-features/server/package-lock.json
-===================================================================
---- third-party-src.orig/extensions/json-language-features/server/package-lock.json
-+++ third-party-src/extensions/json-language-features/server/package-lock.json
-@@ -109,12 +109,6 @@
-         "vscode-languageserver-types": "3.17.6-next.6"
-       }
-     },
--    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
--      "version": "3.17.6-next.6",
--      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.6.tgz",
--      "integrity": "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ==",
--      "license": "MIT"
--    },
-     "node_modules/vscode-languageserver-textdocument": {
-       "version": "1.0.12",
-       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-Index: third-party-src/extensions/emmet/package-lock.json
-===================================================================
---- third-party-src.orig/extensions/emmet/package-lock.json
-+++ third-party-src/extensions/emmet/package-lock.json
-@@ -39,14 +39,6 @@
-         "@emmetio/scanner": "^1.0.4"
-       }
-     },
--    "node_modules/@emmetio/css-parser": {
--      "version": "0.4.0",
--      "resolved": "git+ssh://git@github.com/ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660",
--      "dependencies": {
--        "@emmetio/stream-reader": "^2.2.0",
--        "@emmetio/stream-reader-utils": "^0.1.0"
--      }
--    },
-     "node_modules/@emmetio/html-matcher": {
-       "version": "0.3.3",
-       "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-0.3.3.tgz",
-Index: third-party-src/extensions/html-language-features/server/src/htmlServer.ts
-===================================================================
---- third-party-src.orig/extensions/html-language-features/server/src/htmlServer.ts
-+++ third-party-src/extensions/html-language-features/server/src/htmlServer.ts
-@@ -7,12 +7,11 @@ import {
- 	Connection, TextDocuments, InitializeParams, InitializeResult, RequestType,
- 	DocumentRangeFormattingRequest, Disposable, ServerCapabilities,
- 	ConfigurationRequest, ConfigurationParams, DidChangeWorkspaceFoldersNotification,
--	DocumentColorRequest, ColorPresentationRequest, TextDocumentSyncKind, NotificationType, RequestType0, DocumentFormattingRequest, FormattingOptions, TextEdit,
--	TextDocumentContentRequest
-+	DocumentColorRequest, ColorPresentationRequest, TextDocumentSyncKind, NotificationType, RequestType0, DocumentFormattingRequest, FormattingOptions, TextEdit
- } from 'vscode-languageserver';
- import {
- 	getLanguageModes, LanguageModes, Settings, TextDocument, Position, Diagnostic, WorkspaceFolder, ColorInformation,
--	Range, DocumentLink, SymbolInformation, TextDocumentIdentifier, isCompletionItemData, FILE_PROTOCOL
-+	Range, DocumentLink, SymbolInformation, TextDocumentIdentifier, isCompletionItemData
- } from './modes/languageModes';
- 
- import { format } from './modes/formatting';
-@@ -215,9 +214,6 @@ export function startServer(connection:
- 				interFileDependencies: false,
- 				workspaceDiagnostics: false
- 			},
--			workspace: {
--				textDocumentContent: { schemes: [FILE_PROTOCOL] }
--			}
- 		};
- 		return { capabilities };
- 	});
-@@ -588,18 +584,6 @@ export function startServer(connection:
- 		});
- 	});
- 
--	connection.onRequest(TextDocumentContentRequest.type, (params, token) => {
--		return runSafe(runtime, async () => {
--			for (const languageMode of languageModes.getAllModes()) {
--				const content = await languageMode.getTextDocumentContent?.(params.uri);
--				if (content) {
--					return { text: content };
--				}
--			}
--			return null;
--		}, null, `Error while computing text document content for ${params.uri}`, token);
--	});
--
- 	// Listen on the connection
- 	connection.listen();
- }

--- a/patches/internal/package-overrides.diff
+++ b/patches/internal/package-overrides.diff
@@ -1,0 +1,310 @@
+Package overrides that is needed for producing internal builds.
+
+Index: third-party-src/package.json
+===================================================================
+--- third-party-src.orig/package.json
++++ third-party-src/package.json
+@@ -102,7 +102,7 @@
+     "minimist": "^1.2.6",
+     "native-is-elevated": "0.7.0",
+     "native-watchdog": "^1.4.1",
+-    "node-pty": "^1.1.0-beta33",
++    "node-pty": "1.1.0-beta33",
+     "open": "^8.4.2",
+     "tas-client-umd": "0.2.0",
+     "v8-inspect-profiler": "^0.1.1",
+Index: third-party-src/extensions/emmet/package.json
+===================================================================
+--- third-party-src.orig/extensions/emmet/package.json
++++ third-party-src/extensions/emmet/package.json
+@@ -482,7 +482,7 @@
+     "@types/node": "22.x"
+   },
+   "dependencies": {
+-    "@emmetio/css-parser": "ramya-rao-a/css-parser#vscode",
++    "@emmetio/css-parser": "0.4.0",
+     "@emmetio/html-matcher": "^0.3.3",
+     "@emmetio/math-expression": "^1.0.5",
+     "@vscode/emmet-helper": "^2.8.8",
+Index: third-party-src/extensions/css-language-features/package.json
+===================================================================
+--- third-party-src.orig/extensions/css-language-features/package.json
++++ third-party-src/extensions/css-language-features/package.json
+@@ -994,7 +994,7 @@
+     ]
+   },
+   "dependencies": {
+-    "vscode-languageclient": "^10.0.0-next.15",
++    "vscode-languageclient": "10.0.0-next.9",
+     "vscode-uri": "^3.1.0"
+   },
+   "devDependencies": {
+@@ -1003,5 +1003,13 @@
+   "repository": {
+     "type": "git",
+     "url": "https://github.com/microsoft/vscode.git"
++  },
++  "overrides": {
++    "vscode-jsonrpc": "9.0.0-next.5",
++    "vscode-languageclient": "10.0.0-next.9",
++    "vscode-languageserver-types": "3.17.5",
++    "vscode-languageserver": "10.0.0-next.7",
++    "vscode-languageserver-protocol": "3.17.6-next.7",
++    "vscode-languageserver-textdocument": "1.0.12"
+   }
+ }
+Index: third-party-src/extensions/html-language-features/package.json
+===================================================================
+--- third-party-src.orig/extensions/html-language-features/package.json
++++ third-party-src/extensions/html-language-features/package.json
+@@ -259,7 +259,7 @@
+   },
+   "dependencies": {
+     "@vscode/extension-telemetry": "^0.9.8",
+-    "vscode-languageclient": "^10.0.0-next.15",
++    "vscode-languageclient": "10.0.0-next.9",
+     "vscode-uri": "^3.1.0"
+   },
+   "devDependencies": {
+@@ -268,5 +268,13 @@
+   "repository": {
+     "type": "git",
+     "url": "https://github.com/microsoft/vscode.git"
++  },
++  "overrides": {
++    "vscode-jsonrpc": "9.0.0-next.5",
++    "vscode-languageclient": "10.0.0-next.9",
++    "vscode-languageserver-types": "3.17.5",
++    "vscode-languageserver": "10.0.0-next.7",
++    "vscode-languageserver-protocol": "3.17.6-next.7",
++    "vscode-languageserver-textdocument": "1.0.12"
+   }
+ }
+Index: third-party-src/extensions/json-language-features/package.json
+===================================================================
+--- third-party-src.orig/extensions/json-language-features/package.json
++++ third-party-src/extensions/json-language-features/package.json
+@@ -170,7 +170,7 @@
+   "dependencies": {
+     "@vscode/extension-telemetry": "^0.9.8",
+     "request-light": "^0.8.0",
+-    "vscode-languageclient": "^10.0.0-next.15"
++    "vscode-languageclient": "10.0.0-next.9"
+   },
+   "devDependencies": {
+     "@types/node": "22.x"
+@@ -178,5 +178,13 @@
+   "repository": {
+     "type": "git",
+     "url": "https://github.com/microsoft/vscode.git"
++  },
++  "overrides": {
++    "vscode-jsonrpc": "9.0.0-next.5",
++    "vscode-languageclient": "10.0.0-next.9",
++    "vscode-languageserver-types": "3.17.5",
++    "vscode-languageserver": "10.0.0-next.7",
++    "vscode-languageserver-protocol": "3.17.6-next.7",
++    "vscode-languageserver-textdocument": "1.0.12"
+   }
+ }
+Index: third-party-src/extensions/css-language-features/server/package.json
+===================================================================
+--- third-party-src.orig/extensions/css-language-features/server/package.json
++++ third-party-src/extensions/css-language-features/server/package.json
+@@ -12,7 +12,7 @@
+   "dependencies": {
+     "@vscode/l10n": "^0.0.18",
+     "vscode-css-languageservice": "^6.3.6",
+-    "vscode-languageserver": "^10.0.0-next.13",
++    "vscode-languageserver": "10.0.0-next.7",
+     "vscode-uri": "^3.1.0"
+   },
+   "devDependencies": {
+@@ -27,5 +27,13 @@
+     "install-server-next": "npm install vscode-languageserver@next",
+     "install-server-local": "npm install vscode-languageserver",
+     "test": "node ./test/index.js"
++  },
++  "overrides": {
++    "vscode-jsonrpc": "9.0.0-next.5",
++    "vscode-languageclient": "10.0.0-next.9",
++    "vscode-languageserver-types": "3.17.5",
++    "vscode-languageserver": "10.0.0-next.7",
++    "vscode-languageserver-protocol": "3.17.6-next.7",
++    "vscode-languageserver-textdocument": "1.0.12"
+   }
+ }
+Index: third-party-src/extensions/html-language-features/server/package.json
+===================================================================
+--- third-party-src.orig/extensions/html-language-features/server/package.json
++++ third-party-src/extensions/html-language-features/server/package.json
+@@ -12,8 +12,8 @@
+     "@vscode/l10n": "^0.0.18",
+     "vscode-css-languageservice": "^6.3.6",
+     "vscode-html-languageservice": "^5.5.0",
+-    "vscode-languageserver": "^10.0.0-next.13",
+-    "vscode-languageserver-textdocument": "^1.0.12",
++    "vscode-languageserver": "10.0.0-next.7",
++    "vscode-languageserver-textdocument": "1.0.12",
+     "vscode-uri": "^3.1.0"
+   },
+   "devDependencies": {
+@@ -28,5 +28,13 @@
+     "install-server-next": "npm install vscode-languageserver@next",
+     "install-server-local": "npm install vscode-languageserver",
+     "test": "npm run compile && node ./test/index.js"
++  },
++  "overrides": {
++    "vscode-jsonrpc": "9.0.0-next.5",
++    "vscode-languageclient": "10.0.0-next.9",
++    "vscode-languageserver-types": "3.17.5",
++    "vscode-languageserver": "10.0.0-next.7",
++    "vscode-languageserver-protocol": "3.17.6-next.7",
++    "vscode-languageserver-textdocument": "1.0.12"
+   }
+ }
+Index: third-party-src/extensions/json-language-features/server/package.json
+===================================================================
+--- third-party-src.orig/extensions/json-language-features/server/package.json
++++ third-party-src/extensions/json-language-features/server/package.json
+@@ -16,7 +16,7 @@
+     "jsonc-parser": "^3.3.1",
+     "request-light": "^0.8.0",
+     "vscode-json-languageservice": "^5.6.0",
+-    "vscode-languageserver": "^10.0.0-next.13",
++    "vscode-languageserver": "10.0.0-next.7",
+     "vscode-uri": "^3.1.0"
+   },
+   "devDependencies": {
+@@ -34,5 +34,13 @@
+     "install-server-next": "npm install vscode-languageserver@next",
+     "install-server-local": "npm link vscode-languageserver-server",
+     "version": "git commit -m \"JSON Language Server $npm_package_version\" package.json"
++  },
++  "overrides": {
++    "vscode-jsonrpc": "9.0.0-next.5",
++    "vscode-languageclient": "10.0.0-next.9",
++    "vscode-languageserver-types": "3.17.5",
++    "vscode-languageserver": "10.0.0-next.7",
++    "vscode-languageserver-protocol": "3.17.6-next.7",
++    "vscode-languageserver-textdocument": "1.0.12"
+   }
+ }
+Index: third-party-src/extensions/css-language-features/server/package-lock.json
+===================================================================
+--- third-party-src.orig/extensions/css-language-features/server/package-lock.json
++++ third-party-src/extensions/css-language-features/server/package-lock.json
+@@ -93,12 +93,6 @@
+         "vscode-languageserver-types": "3.17.6-next.6"
+       }
+     },
+-    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
+-      "version": "3.17.6-next.6",
+-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.6.tgz",
+-      "integrity": "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ==",
+-      "license": "MIT"
+-    },
+     "node_modules/vscode-languageserver-textdocument": {
+       "version": "1.0.12",
+       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+Index: third-party-src/extensions/html-language-features/server/package-lock.json
+===================================================================
+--- third-party-src.orig/extensions/html-language-features/server/package-lock.json
++++ third-party-src/extensions/html-language-features/server/package-lock.json
+@@ -107,12 +107,6 @@
+         "vscode-languageserver-types": "3.17.6-next.6"
+       }
+     },
+-    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
+-      "version": "3.17.6-next.6",
+-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.6.tgz",
+-      "integrity": "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ==",
+-      "license": "MIT"
+-    },
+     "node_modules/vscode-languageserver-textdocument": {
+       "version": "1.0.12",
+       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+Index: third-party-src/extensions/json-language-features/server/package-lock.json
+===================================================================
+--- third-party-src.orig/extensions/json-language-features/server/package-lock.json
++++ third-party-src/extensions/json-language-features/server/package-lock.json
+@@ -109,12 +109,6 @@
+         "vscode-languageserver-types": "3.17.6-next.6"
+       }
+     },
+-    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
+-      "version": "3.17.6-next.6",
+-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.6.tgz",
+-      "integrity": "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ==",
+-      "license": "MIT"
+-    },
+     "node_modules/vscode-languageserver-textdocument": {
+       "version": "1.0.12",
+       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+Index: third-party-src/extensions/emmet/package-lock.json
+===================================================================
+--- third-party-src.orig/extensions/emmet/package-lock.json
++++ third-party-src/extensions/emmet/package-lock.json
+@@ -39,14 +39,6 @@
+         "@emmetio/scanner": "^1.0.4"
+       }
+     },
+-    "node_modules/@emmetio/css-parser": {
+-      "version": "0.4.0",
+-      "resolved": "git+ssh://git@github.com/ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660",
+-      "dependencies": {
+-        "@emmetio/stream-reader": "^2.2.0",
+-        "@emmetio/stream-reader-utils": "^0.1.0"
+-      }
+-    },
+     "node_modules/@emmetio/html-matcher": {
+       "version": "0.3.3",
+       "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-0.3.3.tgz",
+Index: third-party-src/extensions/html-language-features/server/src/htmlServer.ts
+===================================================================
+--- third-party-src.orig/extensions/html-language-features/server/src/htmlServer.ts
++++ third-party-src/extensions/html-language-features/server/src/htmlServer.ts
+@@ -7,12 +7,11 @@ import {
+ 	Connection, TextDocuments, InitializeParams, InitializeResult, RequestType,
+ 	DocumentRangeFormattingRequest, Disposable, ServerCapabilities,
+ 	ConfigurationRequest, ConfigurationParams, DidChangeWorkspaceFoldersNotification,
+-	DocumentColorRequest, ColorPresentationRequest, TextDocumentSyncKind, NotificationType, RequestType0, DocumentFormattingRequest, FormattingOptions, TextEdit,
+-	TextDocumentContentRequest
++	DocumentColorRequest, ColorPresentationRequest, TextDocumentSyncKind, NotificationType, RequestType0, DocumentFormattingRequest, FormattingOptions, TextEdit
+ } from 'vscode-languageserver';
+ import {
+ 	getLanguageModes, LanguageModes, Settings, TextDocument, Position, Diagnostic, WorkspaceFolder, ColorInformation,
+-	Range, DocumentLink, SymbolInformation, TextDocumentIdentifier, isCompletionItemData, FILE_PROTOCOL
++	Range, DocumentLink, SymbolInformation, TextDocumentIdentifier, isCompletionItemData
+ } from './modes/languageModes';
+ 
+ import { format } from './modes/formatting';
+@@ -215,9 +214,6 @@ export function startServer(connection:
+ 				interFileDependencies: false,
+ 				workspaceDiagnostics: false
+ 			},
+-			workspace: {
+-				textDocumentContent: { schemes: [FILE_PROTOCOL] }
+-			}
+ 		};
+ 		return { capabilities };
+ 	});
+@@ -588,18 +584,6 @@ export function startServer(connection:
+ 		});
+ 	});
+ 
+-	connection.onRequest(TextDocumentContentRequest.type, (params, token) => {
+-		return runSafe(runtime, async () => {
+-			for (const languageMode of languageModes.getAllModes()) {
+-				const content = await languageMode.getTextDocumentContent?.(params.uri);
+-				if (content) {
+-					return { text: content };
+-				}
+-			}
+-			return null;
+-		}, null, `Error while computing text document content for ${params.uri}`, token);
+-	});
+-
+ 	// Listen on the connection
+ 	connection.listen();
+ }

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -36,3 +36,4 @@ web-embedded/add-default-loader.diff
 web-embedded/fix-watch-target.diff
 web-embedded/remove-unused-recommended-extensions-action.diff
 web-embedded/remove-new-window-actions-and-profile-workspace-section.diff
+web-embedded/only-allow-trusted-origins-in-webviews.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -37,3 +37,4 @@ web-embedded/add-default-loader.diff
 web-embedded/fix-watch-target.diff
 web-embedded/remove-unused-recommended-extensions-action.diff
 web-embedded/remove-new-window-actions-and-profile-workspace-section.diff
+web-embedded/only-allow-trusted-origins-in-webviews.diff

--- a/patches/web-embedded/clean-up-workbench-and-use-tb-cdn-for-webview-in-pro.diff
+++ b/patches/web-embedded/clean-up-workbench-and-use-tb-cdn-for-webview-in-pro.diff
@@ -18,7 +18,7 @@ Index: third-party-src/src/vs/code/browser/workbench/workbench.ts
 +	const urlSearch = new URLSearchParams(mainWindow.location.search);
 +	const origin = urlSearch.get('origin');
 +	const functionName = urlSearch.get('function');
-+	const vsCodeCdn = urlSearch.get('vsCodeCdn');
++	const vsCodeCdn = urlSearch.get('vsCodeCdn') ?? mainWindow.location.origin;
 +	const isDevo = urlSearch.get('isDevo') === 'true';
  	// Find config by checking for DOM
  	const configElement = mainWindow.document.getElementById('vscode-workbench-web-configuration');

--- a/patches/web-embedded/only-allow-trusted-origins-in-webviews.diff
+++ b/patches/web-embedded/only-allow-trusted-origins-in-webviews.diff
@@ -1,0 +1,61 @@
+Only allow opening webviews from same-origin or trusted parent origins
+
+Index: third-party-src/src/vs/workbench/contrib/webview/browser/pre/index.html
+===================================================================
+--- third-party-src.orig/src/vs/workbench/contrib/webview/browser/pre/index.html
++++ third-party-src/src/vs/workbench/contrib/webview/browser/pre/index.html
+@@ -5,7 +5,7 @@
+ 	<meta charset="UTF-8">
+ 
+ 	<meta http-equiv="Content-Security-Policy"
+-		content="default-src 'none'; script-src 'sha256-gEAyFzmkyqMoTTnN+3KReFUYoHsK4RAJEb+6eiul+UY=' 'self'; frame-src 'self';">
++		content="default-src 'none'; script-src 'sha256-tUqLu+qwk/T12Lnj5zY5MJEBU4bPYFxPWddp8PCLxqA=' 'self'; frame-src 'self'; connect-src 'self';">
+ 
+ 	<!-- Disable pinch zooming -->
+ 	<meta name="viewport"
+@@ -343,11 +343,22 @@
+ 			}
+ 
+ 			async signalReady() {
++				const readTrustedOrigins = async () => {
++					const trustedOrigins = new Set([window.location.hostname]);
++					try {
++						const response = await fetch('/product.json', { mode: 'same-origin' });
++						const productConfig = await response.json();
++						return new Set(trustedOrigins.concat(productConfig.webviewTrustedOrigins ?? [])).union(trustedOrigins);
++					} catch (error) {
++						return trustedOrigins;
++					}
++				}
++
+ 				const start = (/** @type {string} */ parentOrigin) => {
+ 					window.parent.postMessage({ target: ID, channel: 'webview-ready', data: {} }, parentOrigin, [this.channel.port2]);
+ 				};
+ 
+-				const parentOrigin = searchParams.get('parentOrigin');
++				const parentOrigin = searchParams.get('parentOrigin') ?? '';
+ 
+ 				const hostname = location.hostname;
+ 
+@@ -356,6 +367,12 @@
+ 					throw new Error(`'crypto.subtle' is not available so webviews will not work. This is likely because the editor is not running in a secure context (https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).`);
+ 				}
+ 
++				const trustedOrigins = await readTrustedOrigins();
++
++				if(trustedOrigins.has(URL.parse(parentOrigin)?.hostname)) {
++					return start(parentOrigin);
++				}
++
+ 				// Here the `parentOriginHash()` function from `src/vs/workbench/common/webview.ts` is inlined
+ 				// compute a sha-256 composed of `parentOrigin` and `salt` converted to base 32
+ 				let parentOriginHash;
+@@ -377,7 +394,7 @@
+ 					return start(parentOrigin);
+ 				}
+ 
+-				throw new Error(`Expected '${parentOriginHash}' as hostname or subdomain!`);
++				throw new Error('Parent origin is not trusted!');
+ 			}
+ 		}();
+ 

--- a/patches/web-server/integration.diff
+++ b/patches/web-server/integration.diff
@@ -2,7 +2,7 @@ Index: third-party-src/product.json
 ===================================================================
 --- third-party-src.orig/product.json
 +++ third-party-src/product.json
-@@ -1,18 +1,32 @@
+@@ -1,18 +1,33 @@
  {
 -	"nameShort": "Code - OSS",
 -	"nameLong": "Code - OSS",
@@ -12,6 +12,7 @@ Index: third-party-src/product.json
 +		"serviceUrl": "https://open-vsx.org/vscode/gallery",
 +		"itemUrl": "https://open-vsx.org/vscode/item",
 +		"resourceUrlTemplate": "https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/{path}",
++		"extensionUrlTemplate": "https://open-vsx.org/vscode/gallery/{publisher}/{name}/latest",
 +		"controlUrl": "",
 +		"recommendationsUrl": "",
 +		"nlsBaseUrl": "",

--- a/patches/web-server/marketplace.diff
+++ b/patches/web-server/marketplace.diff
@@ -3,6 +3,9 @@ Adjusted from (MIT licensed) original source:
 
 Add Open VSX as default marketplace
 
+Adjusted ExtensionLatestVersionUri endpoint to be compatible with OpenVSX API
+(see: https://open-vsx.org/swagger-ui/index.html?urls.primaryName=VSCode%20Adapter)
+
 Index: third-party-src/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- third-party-src.orig/src/vs/server/node/webClientServer.ts
@@ -40,3 +43,16 @@ Index: third-party-src/src/vs/platform/extensionResourceLoader/common/extensionR
  	}
  
  }
+Index: third-party-src/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
+===================================================================
+--- third-party-src.orig/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
++++ third-party-src/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
+@@ -46,7 +46,7 @@ export class ExtensionGalleryManifestSer
+ 				type: ExtensionGalleryResourceType.ExtensionQueryService
+ 			},
+ 			{
+-				id: `${extensionsGallery.serviceUrl}/vscode/{publisher}/{name}/latest`,
++				id: `${extensionsGallery.serviceUrl}/{publisher}/{name}/latest`,
+ 				type: ExtensionGalleryResourceType.ExtensionLatestVersionUri
+ 			},
+ 			{

--- a/patches/web-server/proxy-uri.diff
+++ b/patches/web-server/proxy-uri.diff
@@ -1,4 +1,35 @@
-
+Index: third-party-src/package.json
+===================================================================
+--- third-party-src.orig/package.json
++++ third-party-src/package.json
+@@ -96,6 +96,7 @@
+     "@xterm/addon-webgl": "^0.19.0-beta.107",
+     "@xterm/headless": "^5.6.0-beta.107",
+     "@xterm/xterm": "^5.6.0-beta.107",
++    "http-proxy": "^1.18.1",
+     "http-proxy-agent": "^7.0.0",
+     "https-proxy-agent": "^7.0.2",
+     "jschardet": "3.1.4",
+@@ -121,6 +122,7 @@
+     "@types/debug": "^4.1.5",
+     "@types/eslint": "^9.6.1",
+     "@types/gulp-svgmin": "^1.2.1",
++    "@types/http-proxy": "^1.17.15",
+     "@types/http-proxy-agent": "^2.0.1",
+     "@types/kerberos": "^1.1.2",
+     "@types/minimist": "^1.2.1",
+Index: third-party-src/remote/package.json
+===================================================================
+--- third-party-src.orig/remote/package.json
++++ third-party-src/remote/package.json
+@@ -26,6 +26,7 @@
+     "@xterm/headless": "^5.6.0-beta.107",
+     "@xterm/xterm": "^5.6.0-beta.107",
+     "cookie": "^0.7.0",
++    "http-proxy": "^1.18.1",
+     "http-proxy-agent": "^7.0.0",
+     "https-proxy-agent": "^7.0.2",
+     "jschardet": "3.1.4",
 Index: third-party-src/src/vs/code/browser/workbench/workbench.ts
 ===================================================================
 --- third-party-src.orig/src/vs/code/browser/workbench/workbench.ts


### PR DESCRIPTION
**Description of changes:**

Updated and reorganised patches:
- Regenerated `LICENSE-THIRD-PARTY` file
- Fixed typo in trusted domains configuration
- Fixed webview loading for web-embedded flavour
  - Use same-origin root as fallback for webview path prefix
  - Added `webviewTrustedOrigins` configuration option
- Split internal patches into two
- Fix for OpenVSX extension installation when an unpinned extension is installed from the CLI with no extension host running


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
