### PR TITLE
Modifying existing patches and adding sagemaker integration patch

### DIFF
--- a/patches/common/update-csp.diff
+++ b/patches/common/update-csp.diff
@@ -1,0 +1,13 @@
+Index: sagemaker-code-editor/vscode/src/vs/server/node/webClientServer.ts
+===================================================================
+--- third-party-src.orig/src/vs/server/node/webClientServer.ts
++++ third-party-src/src/vs/server/node/webClientServer.ts
+@@ -375,7 +375,7 @@ export class WebClientServer {
+ 			`frame-src 'self' https://*.vscode-cdn.net data:;`,
+ 			'worker-src \'self\' data: blob:;',
+ 			'style-src \'self\' \'unsafe-inline\';',
+-			'connect-src \'self\' ws: wss: https:;',
++			'connect-src \'self\' ws: wss: https://main.vscode-cdn.net http://localhost:* https://localhost:* https://login.microsoftonline.com/ https://update.code.visualstudio.com https://*.vscode-unpkg.net/ https://default.exp-tas.com/vscode/ab https://vscode-sync.trafficmanager.net https://vscode-sync-insiders.trafficmanager.net https://*.gallerycdn.vsassets.io https://marketplace.visualstudio.com https://openvsxorg.blob.core.windows.net https://az764295.vo.msecnd.net  https://code.visualstudio.com https://*.gallery.vsassets.io https://*.rel.tunnels.api.visualstudio.com wss://*.rel.tunnels.api.visualstudio.com https://*.servicebus.windows.net/ https://vscode.blob.core.windows.net https://vscode.search.windows.net https://vsmarketplacebadges.dev https://vscode.download.prss.microsoft.com https://download.visualstudio.microsoft.com https://*.vscode-unpkg.net https://open-vsx.org;',
+ 			'font-src \'self\' blob:;',
+ 			'manifest-src \'self\';'
+ 		].join(' ');

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -11,6 +11,7 @@ common/remove-vsda.diff
 common/embedded-api.diff
 common/remove-disable-prompting-for-non-trusted-urls-option.diff
 common/suppress-known-errors-script.diff
+common/update-csp.diff
 web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff
 web-server/base-path.diff
@@ -29,4 +30,5 @@ sagemaker/sagemaker-extension-smus-support.diff
 sagemaker/post-startup-notifications.diff
 sagemaker/sagemaker-extensions-sync.diff
 sagemaker/sagemaker-ui-post-startup.diff
+sagemaker/sagemaker-integration.diff
 sagemaker/sagemaker-idle-extension.diff

--- a/patches/sagemaker/sagemaker-integration.diff
+++ b/patches/sagemaker/sagemaker-integration.diff
@@ -1,0 +1,126 @@
+Index: third-party-src/src/vs/workbench/browser/client.ts
+===================================================================
+--- /dev/null
++++ third-party-src/src/vs/workbench/browser/client.ts
+@@ -0,0 +1,61 @@
++import { Disposable } from '../../base/common/lifecycle.js';
++import { CommandsRegistry } from '../../platform/commands/common/commands.js';
++import { MenuId, MenuRegistry } from '../../platform/actions/common/actions.js';
++import { localize } from '../../nls.js';
++import { ILogService } from '../../platform/log/common/log.js';
++
++export class SagemakerServerClient extends Disposable {
++	constructor (
++		@ILogService private logService: ILogService
++	) {
++		super();
++
++		this.logService.debug('Initializing SagemakerServerClient...');
++		this.registerSagemakerCommands();
++	}
++
++	static LOGOUT_COMMAND_ID = 'sagemaker.logout';
++	static COOKIE_COMMAND_ID = 'sagemaker.parseCookies';
++
++	private registerSagemakerCommands() {
++		const authMode: string | undefined = this.getCookieValue('authMode');
++		const expiryTime: string | undefined = this.getCookieValue('expiryTime');
++		const studioUserProfileName: string | undefined = this.getCookieValue('studioUserProfileName')
++		const ssoExpiryTimestamp: string | undefined = this.getCookieValue('ssoExpiryTimestamp')
++		const redirectURL: string | undefined = this.getCookieValue('redirectURL')
++
++		this.logService.debug('Registering sagemaker commands...');
++
++		CommandsRegistry.registerCommand(SagemakerServerClient.COOKIE_COMMAND_ID, () => {
++			return {
++				authMode: authMode,
++				expiryTime: expiryTime,
++				ssoExpiryTimestamp: ssoExpiryTimestamp,
++				studioUserProfileName: studioUserProfileName,
++				redirectURL: redirectURL
++			};
++		});
++
++		CommandsRegistry.registerCommand(SagemakerServerClient.LOGOUT_COMMAND_ID, () => {
++			const currentUrl = new URL(window.location.href);
++			const hostname = currentUrl.hostname;
++			const pathComponents = currentUrl.pathname.split('/');
++			const logoutUrl = `https://${hostname}/${pathComponents[1]}/${pathComponents[2]}/logout`;
++			window.location.href = logoutUrl;
++		});
++
++		for (const menuId of [MenuId.CommandPalette, MenuId.MenubarHomeMenu]) {
++			MenuRegistry.appendMenuItem(menuId, {
++				command: {
++					id: SagemakerServerClient.LOGOUT_COMMAND_ID,
++					title: localize('logout', "{0}: Log out", 'Sagemaker'),
++				},
++			});
++		}
++	}
++
++	private getCookieValue(name: string): string | undefined {
++		const match = document.cookie.match('(^|[^;]+)\\s*' + name + '\\s*=\\s*([^;]+)'); // See https://stackoverflow.com/a/25490531
++		return match ? match.pop() : undefined;
++	}
++}
+\ No newline at end of file
+Index: third-party-src/src/vs/workbench/browser/web.main.ts
+===================================================================
+--- third-party-src.orig/src/vs/workbench/browser/web.main.ts
++++ third-party-src/src/vs/workbench/browser/web.main.ts
+@@ -95,6 +95,7 @@ import { TunnelSource } from 'vs/workbench/services/re
+ import { TunnelSource } from '../services/remote/common/tunnelModel.js';
+ import { mainWindow } from '../../base/browser/window.js';
+ import { INotificationService, Severity } from '../../platform/notification/common/notification.js';
++import { SagemakerServerClient } from '../../workbench/browser/client.js';
+ 
+ export class BrowserMain extends Disposable {
+ 
+@@ -129,6 +130,9 @@ export class BrowserMain extends Disposable {
+ 
+ 		// Startup
+ 		const instantiationService = workbench.startup();
++
++		// Create instance of SagemakerServerClient
++		this._register(instantiationService.createInstance(SagemakerServerClient));
+ 
+ 		// Window
+ 		this._register(instantiationService.createInstance(BrowserWindow));
+Index: third-party-src/product.json
+===================================================================
+--- third-party-src.orig/product.json
++++ third-party-src/product.json
+@@ -16,6 +16,6 @@
+ 	],
+-	"nameShort": "Code Editor",
+-	"nameLong": "Code Editor",
++	"nameShort": "SageMaker Code Editor",
++	"nameLong": "SageMaker Code Editor",
+ 	"applicationName": "code",
+ 	"dataFolderName": ".vscode-editor",
+ 	"win32MutexName": "vscodeoss",
+Index: third-party-src/src/vs/platform/product/common/product.ts
+===================================================================
+--- third-party-src.orig/src/vs/platform/product/common/product.ts
++++ third-party-src/src/vs/platform/product/common/product.ts
+@@ -69,15 +69,17 @@ else {
+ 	if (Object.keys(product).length === 0) {
+ 		Object.assign(product, {
+ 			version: '1.95.0-dev',
+-			nameShort: 'Code Editor',
+-			nameLong: 'Code Editor',
++			nameShort: 'SageMaker Code Editor',
++			nameLong: 'SageMaker Code Editor',
+ 			applicationName: 'code-oss',
+ 			dataFolderName: '.vscode-oss',
++			commit: "hellocommit",
++			date: "hellodate",
+ 			urlProtocol: 'code-oss',
+ 			reportIssueUrl: 'https://github.com/microsoft/vscode/issues/new',
+ 			licenseName: 'MIT',
+ 			licenseUrl: 'https://github.com/microsoft/vscode/blob/main/LICENSE.txt',
+			serverLicenseUrl: 'https://github.com/microsoft/vscode/blob/main/LICENSE.txt'
+ 		});
+ 	}
+ }

--- a/patches/web-server/integration.diff
+++ b/patches/web-server/integration.diff
@@ -127,6 +127,198 @@ Index: third-party-src/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
  				this.productService.version || 'Unknown',
  				this.productService.commit || 'Unknown',
  				this.productService.date ? `${this.productService.date}${useAgo ? ' (' + fromNow(new Date(this.productService.date), true) + ')' : ''}` : 'Unknown',
+Index: third-party-src/extensions/git/package.nls.json
+===================================================================
+--- third-party-src.orig/extensions/git/package.nls.json
++++ third-party-src/extensions/git/package.nls.json
+@@ -226,7 +226,7 @@
+ 		"message": "List of git commands (ex: commit, push) that would have their `stdout` logged to the [git output](command:git.showOutput). If the git command has a client-side hook configured, the client-side hook's `stdout` will also be logged to the [git output](command:git.showOutput).",
+ 		"comment": [
+ 			"{Locked='](command:git.showOutput'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+@@ -254,8 +254,8 @@
+ 	"config.untrackedChanges.hidden": "Untracked changes are hidden and excluded from several actions.",
+ 	"config.requireGitUserConfig": "Controls whether to require explicit Git user configuration or allow Git to guess if missing.",
+ 	"config.showCommitInput": "Controls whether to show the commit input in the Git source control panel.",
+-	"config.terminalAuthentication": "Controls whether to enable VS Code to be the authentication handler for Git processes spawned in the Integrated Terminal. Note: Terminals need to be restarted to pick up a change in this setting.",
+-	"config.terminalGitEditor": "Controls whether to enable VS Code to be the Git editor for Git processes spawned in the integrated terminal. Note: Terminals need to be restarted to pick up a change in this setting.",
++	"config.terminalAuthentication": "Controls whether to enable Code-OSS to be the authentication handler for Git processes spawned in the Integrated Terminal. Note: Terminals need to be restarted to pick up a change in this setting.",
++	"config.terminalGitEditor": "Controls whether to enable Code-OSS to be the Git editor for Git processes spawned in the integrated terminal. Note: Terminals need to be restarted to pick up a change in this setting.",
+ 	"config.timeline.showAuthor": "Controls whether to show the commit author in the Timeline view.",
+ 	"config.timeline.showUncommitted": "Controls whether to show uncommitted changes in the Timeline view.",
+ 	"config.timeline.date": "Controls which date to use for items in the Timeline view.",
+@@ -322,7 +322,7 @@
+ 			"{Locked='](command:workbench.action.reloadWindow'}",
+			"{Locked='](command:git.showOutput'}",
+			"{Locked='](command:workbench.extensions.search?%22%40category%3A%5C%22scm%20providers%5C%22%22'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+@@ -332,7 +332,7 @@
+ 			"{Locked='](command:workbench.action.reloadWindow'}",
+			"{Locked='](command:git.showOutput'}",
+			"{Locked='](command:workbench.extensions.search?%22%40category%3A%5C%22scm%20providers%5C%22%22'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+@@ -342,54 +342,54 @@
+ 			"{Locked='](command:workbench.action.reloadWindow'}",
+ 			"{Locked='](command:git.showOutput'}",
+ 			"{Locked='](command:workbench.extensions.search?%22%40category%3A%5C%22scm%20providers%5C%22%22'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+ 	"view.workbench.scm.missing": {
+-		"message": "Install Git, a popular source control system, to track code changes and collaborate with others. Learn more in our [Git guides](https://aka.ms/vscode-scm).",
++		"message": "Install Git, a popular source control system, to track code changes and collaborate with others. Learn more in our [Git guides](https://aka.ms/vscode-scm).",
+ 		"comment": [
+ 			"{Locked='](https://aka.ms/vscode-scm'}",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+ 	"view.workbench.scm.disabled": {
+-		"message": "If you would like to use Git features, please enable Git in your [settings](command:workbench.action.openSettings?%5B%22git.enabled%22%5D).\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
++		"message": "If you would like to use Git features, please enable Git in your [settings](command:workbench.action.openSettings?%5B%22git.enabled%22%5D).\nTo learn more about how to use Git and source control in Code-OSS [read our docs](https://aka.ms/vscode-scm).",
+ 		"comment": [
+ 			"{Locked='](command:workbench.action.openSettings?%5B%22git.enabled%22%5D'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+ 	"view.workbench.scm.empty": {
+-		"message": "In order to use Git features, you can open a folder containing a Git repository or clone from a URL.\n[Open Folder](command:vscode.openFolder)\n[Clone Repository](command:git.cloneRecursive)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
++		"message": "In order to use Git features, you can open a folder containing a Git repository or clone from a URL.\n[Open Folder](command:vscode.openFolder)\n[Clone Repository](command:git.clone)\nTo learn more about how to use Git and source control in Code-OSS [read our docs](https://aka.ms/vscode-scm).",
+ 		"comment": [
+ 			"{Locked='](command:vscode.openFolder'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+ 	"view.workbench.scm.folder": {
+-		"message": "The folder currently open doesn't have a Git repository. You can initialize a repository which will enable source control features powered by Git.\n[Initialize Repository](command:git.init?%5Btrue%5D)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
++		"message": "The folder currently open doesn't have a Git repository. You can initialize a repository which will enable source control features powered by Git.\n[Initialize Repository](command:git.init?%5Btrue%5D)\nTo learn more about how to use Git and source control in Code-OSS [read our docs](https://aka.ms/vscode-scm).",
+ 		"comment": [
+ 			"{Locked='](command:git.init?%5Btrue%5D'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+ 	"view.workbench.scm.workspace": {
+-		"message": "The workspace currently open doesn't have any folders containing Git repositories. You can initialize a repository on a folder which will enable source control features powered by Git.\n[Initialize Repository](command:git.init)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
++		"message": "The workspace currently open doesn't have any folders containing Git repositories. You can initialize a repository on a folder which will enable source control features powered by Git.\n[Initialize Repository](command:git.init)\nTo learn more about how to use Git and source control in Code-OSS [read our docs](https://aka.ms/vscode-scm).",
+ 		"comment": [
+ 			"{Locked='](command:git.init'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+ 	"view.workbench.scm.emptyWorkspace": {
+-		"message": "The workspace currently open doesn't have any folders containing Git repositories.\n[Add Folder to Workspace](command:workbench.action.addRootFolder)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
++		"message": "The workspace currently open doesn't have any folders containing Git repositories.\n[Add Folder to Workspace](command:workbench.action.addRootFolder)\nTo learn more about how to use Git and source control in Code-OSS [read our docs](https://aka.ms/vscode-scm).",
+ 		"comment": [
+ 			"{Locked='](command:workbench.action.addRootFolder'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+@@ -404,7 +404,7 @@
+ 		"comment": [
+ 			"{Locked='](command:git.openRepositoriesInParentFolders'}",
+ 			"{Locked='](command:workbench.action.openSettings?%5B%22git.openRepositoryInParentFolders%22%5D'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+@@ -413,7 +413,7 @@
+ 		"comment": [
+ 			"{Locked='](command:git.openRepositoriesInParentFolders'}",
+ 			"{Locked='](command:workbench.action.openSettings?%5B%22git.openRepositoryInParentFolders%22%5D'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+@@ -421,7 +421,7 @@
+ 		"message": "The detected Git repository is potentially unsafe as the folder is owned by someone other than the current user.\n[Manage Unsafe Repositories](command:git.manageUnsafeRepositories)\nTo learn more about unsafe repositories [read our docs](https://aka.ms/vscode-git-unsafe-repository).",
+ 		"comment": [
+ 			"{Locked='](command:git.manageUnsafeRepositories'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+@@ -429,23 +429,23 @@
+ 		"message": "The detected Git repositories are potentially unsafe as the folders are owned by someone other than the current user.\n[Manage Unsafe Repositories](command:git.manageUnsafeRepositories)\nTo learn more about unsafe repositories [read our docs](https://aka.ms/vscode-git-unsafe-repository).",
+ 		"comment": [
+ 			"{Locked='](command:git.manageUnsafeRepositories'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+ 	"view.workbench.scm.closedRepository": {
+-		"message": "A Git repository was found that was previously closed.\n[Reopen Closed Repository](command:git.reopenClosedRepositories)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
++		"message": "A Git repository was found that was previously closed.\n[Reopen Closed Repository](command:git.reopenClosedRepositories)\nTo learn more about how to use Git and source control in Code-OSS [read our docs](https://aka.ms/vscode-scm).",
+ 		"comment": [
+ 			"{Locked='](command:git.reopenClosedRepositories'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+ 	"view.workbench.scm.closedRepositories": {
+-		"message": "Git repositories were found that were previously closed.\n[Reopen Closed Repositories](command:git.reopenClosedRepositories)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
++		"message": "Git repositories were found that were previously closed.\n[Reopen Closed Repositories](command:git.reopenClosedRepositories)\nTo learn more about how to use Git and source control in Code-OSS [read our docs](https://aka.ms/vscode-scm).",
+ 		"comment": [
+ 			"{Locked='](command:git.reopenClosedRepositories'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+@@ -453,9 +453,9 @@
+ 		"message": "You can clone a repository locally.\n[Clone Repository](command:git.clone 'Clone a repository once the Git extension has activated')",
+ 		"comment": [
+ 			"{Locked='](command:git.clone'}",
+-			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
++			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for Code-OSS",
+ 			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
+ 		]
+ 	},
+-	"view.workbench.learnMore": "To learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm)."
++	"view.workbench.learnMore": "To learn more about how to use Git and source control in Code-OSS [read our docs](https://aka.ms/vscode-scm)."
+ }
+Index: third-party-src/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+===================================================================
+--- third-party-src.orig/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
++++ third-party-src/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+@@ -357,8 +357,8 @@ export const walkthroughs: GettingStartedWalkthroughCo
+ 
+ 	{
+ 		id: 'SetupWeb',
+-		title: localize('gettingStarted.setupWeb.title', "Get Started with VS Code for the Web"),
+-		description: localize('gettingStarted.setupWeb.description', "Customize your editor, learn the basics, and start coding"),
++		title: localize('gettingStarted.setupWeb.title', "Get Started with Code Editor"),
++		description: localize('gettingStarted.setupWeb.description', "Discover the best customizations to make Code Editor yours."),
+ 		isFeatured: true,
+ 		icon: setupIcon,
+ 		when: 'isWeb',
 Index: third-party-src/src/vs/workbench/workbench.common.main.ts
 ===================================================================
 --- third-party-src.orig/src/vs/workbench/workbench.common.main.ts

--- a/patches/web-server/marketplace.diff
+++ b/patches/web-server/marketplace.diff
@@ -56,3 +56,77 @@ Index: third-party-src/src/vs/platform/extensionManagement/common/extensionGalle
  				type: ExtensionGalleryResourceType.ExtensionLatestVersionUri
  			},
  			{
+Index: sagemaker-code-editor/vscode/src/vs/platform/product/common/product.ts
+===================================================================
+--- third-party-src.orig/src/vs/platform/product/common/product.ts
++++ third-party-src/src/vs/platform/product/common/product.ts
+@@ -49,6 +49,14 @@ else if (globalThis._VSCODE_PRODUCT_JSON
+ 			version: pkg.version
+ 		});
+ 	}
++
++	if (env['EXTENSIONS_GALLERY']) {
++		console.log(`Custom extensions gallery detected. Parsing...`);
++		Object.assign(product, {
++			extensionsGallery: JSON.parse(env['EXTENSIONS_GALLERY'])
++		});
++	}
++	console.log(JSON.stringify(product.extensionsGallery, null, 2));
+ }
+ 
+ // Web environment or unknown
+Index: third-party-src/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+===================================================================
+--- third-party-src.orig/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
++++ third-party-src/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+@@ -70,6 +70,8 @@ import { ILocalizedString } from '../../../../pla
+ import { IExtensionGalleryManifest, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+ import { URI } from '../../../../base/common/uri.js';
+ import { IMcpGalleryService } from '../../../../platform/mcp/common/mcpManagement.js';
++import { IProductService } from '../../../../platform/product/common/productService.js';
++import { memoize } from '../../../../base/common/decorators.js';
+ 
+ export const ExtensionsSortByContext = new RawContextKey<string>('extensionsSortByValue', '');
+ export const SearchMarketplaceExtensionsContext = new RawContextKey<boolean>('searchMarketplaceExtensions', false);
+@@ -93,7 +93,6 @@ const SortByUpdateDateContext = new RawC
+ const REMOTE_CATEGORY: ILocalizedString = localize2({ key: 'remote', comment: ['Remote as in remote machine'] }, "Remote");
+ 
+ export class ExtensionsViewletViewsContribution extends Disposable implements IWorkbenchContribution {
+-
+ 	private readonly container: ViewContainer;
+ 
+ 	constructor(
+@@ -528,6 +528,7 @@ export class ExtensionsViewPaneContainer
+ 		@IExtensionService extensionService: IExtensionService,
+ 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
+ 		@IPreferencesService private readonly preferencesService: IPreferencesService,
++		@IProductService private readonly productService: IProductService,
+ 		@ICommandService private readonly commandService: ICommandService,
+ 		@IMcpGalleryService private readonly mcpGalleryService: IMcpGalleryService,
+ 		@ILogService logService: ILogService,
+@@ -569,6 +571,15 @@ export class ExtensionsViewPaneContainer
+ 			});
+ 	}
+ 
++	@memoize
++	get extensionsGalleryHostname(): string {
++		if (this.productService.extensionsGallery?.serviceUrl) {
++			return new URL(this.productService.extensionsGallery?.serviceUrl).hostname;
++		}
++
++		return 'Marketplace';
++	}
++
+ 	get searchValue(): string | undefined {
+ 		return this.searchBox?.getValue();
+ 	}
+@@ -583,8 +594,7 @@ export class ExtensionsViewPaneContainer
+		hide(overlay);
+
+		this.header = append(this.root, $('.header'));
+-		const placeholder = localize('searchExtensions', "Search Extensions in Marketplace");
+-
++		const placeholder = localize('searchExtensions', 'Search extensions in {0}', this.extensionsGalleryHostname);
+ 		const searchValue = this.searchViewletState['query.value'] ? this.searchViewletState['query.value'] : '';
+ 
+ 		const searchContainer = append(this.header, $('.extensions-search-container'));


### PR DESCRIPTION
*Description of changes:*
Reorganised sagemaker patches as follows:
- [patches/custom-extensions-marketplace.diff](https://github.com/aws/sagemaker-code-editor/blob/1.6/patches/custom-extensions-marketplace.diff): Moved the logic to override the Custom extensions gallery to marketplace.diff 
- CSP policy update from [patches/display-language.patch](https://github.com/aws/sagemaker-code-editor/blob/1.6/patches/display-language.patch) combined with [patches/update-csp.diff](https://github.com/aws/sagemaker-code-editor/blob/1.6/patches/update-csp.diff) and moved to the list of common patches. 
- Moved common renaming logic from [sagemaker/sagemaker-integration.diff](https://github.com/aws/sagemaker-code-editor/blob/1.7/patches/sagemaker-integration.diff) to [web-server/integration.diff](https://github.com/aws/code-editor/blob/main/patches/web-server/integration.diff).

Testing: Created a Sagemaker distribution image using all sagemaker patches and created a code editor application on Sagemaker Studio using that.

<img width="1728" height="1080" alt="Screenshot 2025-07-31 at 15 33 39" src="https://github.com/user-attachments/assets/8eb8daa1-3580-46fd-9fed-6e29ff89ecf6" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
