### PR TITLE
do not use module type for service worker

### DIFF
--- a/patches/common/service-worker-fix.diff
+++ b/patches/common/service-worker-fix.diff
@@ -1,0 +1,16 @@
+Do not use module type for service worker. Otherwise it will cause browser to not send cookies, which can result
+in a 401.
+
+Index: third-party-src/src/vs/workbench/contrib/webview/browser/pre/index.html
+===================================================================
+--- third-party-src.orig/src/vs/workbench/contrib/webview/browser/pre/index.html
++++ third-party-src/src/vs/workbench/contrib/webview/browser/pre/index.html
+@@ -238,7 +238,7 @@
+ 			}
+ 
+ 			const swPath = encodeURI(`service-worker.js?v=${expectedWorkerVersion}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}`);
+-			navigator.serviceWorker.register(swPath, { type: 'module' })
++			navigator.serviceWorker.register(swPath)
+ 				.then(async registration => {
+ 					/**
+ 					 * @param {MessageEvent} event

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -11,6 +11,7 @@ common/remove-vsda.diff
 common/embedded-api.diff
 common/remove-disable-prompting-for-non-trusted-urls-option.diff
 common/suppress-known-errors-script.diff
+common/service-worker-fix.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff
@@ -37,3 +38,5 @@ web-embedded/fix-watch-target.diff
 web-embedded/remove-unused-recommended-extensions-action.diff
 web-embedded/remove-new-window-actions-and-profile-workspace-section.diff
 web-embedded/only-allow-trusted-origins-in-webviews.diff
+internal/build.diff
+internal/package-overrides.diff

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -38,5 +38,3 @@ web-embedded/fix-watch-target.diff
 web-embedded/remove-unused-recommended-extensions-action.diff
 web-embedded/remove-new-window-actions-and-profile-workspace-section.diff
 web-embedded/only-allow-trusted-origins-in-webviews.diff
-internal/build.diff
-internal/package-overrides.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -11,6 +11,7 @@ common/remove-vsda.diff
 common/embedded-api.diff
 common/remove-disable-prompting-for-non-trusted-urls-option.diff
 common/suppress-known-errors-script.diff
+common/service-worker-fix.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -11,6 +11,7 @@ common/remove-vsda.diff
 common/embedded-api.diff
 common/remove-disable-prompting-for-non-trusted-urls-option.diff
 common/suppress-known-errors-script.diff
+common/service-worker-fix.diff
 web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff
 web-server/base-path.diff


### PR DESCRIPTION
*Issue #, if available:*

https://t.corp.amazon.com/D280920991

*Description of changes:*

Follow fix in [code-server](https://github.com/coder/code-server/commit/c5c764d78fd069afc2cc43cfa1bff805dd5a169f#diff-fad085bd3a715709e43da0f9f405a662e64a4896c58f7253c9996de4828808a3) to not use module type in service worker registration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
