### PR TITLE
Added artifacts upload

### DIFF
--- a/.github/workflows/build-targets.yaml
+++ b/.github/workflows/build-targets.yaml
@@ -14,15 +14,15 @@ jobs:
     environment: build-targets-workflow-env
     strategy:
       matrix:
-        build-targets: [code-editor-server, code-editor-sagemaker-server, code-editor-web-embedded]
+        build-target: [code-editor-server, code-editor-sagemaker-server, code-editor-web-embedded]
         exclude:
           # Only build SageMaker for now, remove the excluded targets when needed in the future.
-          - build-targets: code-editor-server
-          - build-targets: code-editor-web-embedded
+          - build-target: code-editor-server
+          - build-target: code-editor-web-embedded
     steps:
       - name: Start Build Workflow
         run: |
-          echo "Starting Build Workflow for target: ${{ matrix.build-targets }}"
+          echo "Starting Build Workflow for target: ${{ matrix.build-target }}"
         
       - name: Set up build environment
         run: |
@@ -53,4 +53,24 @@ jobs:
       
       - name: Build artifacts 
         run: |
-          ./scripts/build-artifacts.sh ${{ matrix.build-targets }}
+          ./scripts/build-artifacts.sh ${{ matrix.build-target }}
+      
+      - name: Prepare artifacts to upload
+        run: |
+          BUILD_TARGET=$(./scripts/determine-build-target.sh ${{ matrix.build-target }})
+          tar -czf code-editor-src.tar.gz ./code-editor-src
+          tar -czf build.tar.gz ./$BUILD_TARGET
+      
+      - name: Upload src artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.sha }}-${{ matrix.build-target }}-src
+          path: code-editor-src.tar.gz
+          retention-days: 90
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.sha }}-${{ matrix.build-target }}-build
+          path: build.tar.gz
+          retention-days: 90

--- a/scripts/build-artifacts.sh
+++ b/scripts/build-artifacts.sh
@@ -6,24 +6,6 @@ get_mem_available_kb() {
     grep MemAvailable /proc/meminfo | awk '{print $2}'
 }
 
-determine_build_target() {
-    local target="$1"
-    local arch=$(uname -m)
-    
-    case "$target" in
-        "code-editor-server"|"code-editor-sagemaker-server")
-            echo "vscode-reh-web-linux-x64"
-            ;;
-        "code-editor-web-embedded")
-            echo "vscode-web"
-            ;;
-        *)
-            echo "Error: Unknown target: $target" >&2
-            exit 1
-            ;;
-    esac
-}
-
 build() {
     local code_oss_build_target_base="$1"
     
@@ -51,11 +33,9 @@ build() {
 
 main() {
     local target="${1:-code-editor-sagemaker-server}"
-
-    # for debugging, will remove later
-    uname -a
     
-    local build_target_base=$(determine_build_target "$target")
+    local build_target_base=$("$(dirname "$0")/determine-build-target.sh" "$target")
+    echo "Building for target: $build_target_base"
     build "$build_target_base"
 }
 

--- a/scripts/determine-build-target.sh
+++ b/scripts/determine-build-target.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+determine_build_target() {
+    local target="$1"
+    local arch=$(uname -m)
+
+    arch=${arch/x86_64/x64}
+    
+    case "$target" in
+        "code-editor-server"|"code-editor-sagemaker-server")
+            echo "vscode-reh-web-linux-${arch}"
+            ;;
+        "code-editor-web-embedded")
+            echo "vscode-web"
+            ;;
+        *)
+            echo "Error: Unknown target: $target" >&2
+            exit 1
+            ;;
+    esac
+}
+
+determine_build_target "$1"


### PR DESCRIPTION
*Description of changes:*
- Renamed `build-target`
- Added 3 steps to build workflow:
    - Preparing archives for upload: `code-editor-src` and `vscode-reh-web-linux-{os arch}` folders
    - 2 step to upload builded artifacts
- Moved code that determines build target to a separate script (this script is used in `Prepare artifacts to upload` step and in `scripts/build-artifacts.sh`)

*Testing*
- tested locally
- test workflow run: https://github.com/aderende/code-editor/actions/runs/16909223564/job/47906222145

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
