### PR TITLE
Added explanation for package-lock-overrides folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is the repo for `code-editor`.
 
 The repository structure is the following:
 - `overrides`: Non-code asset overrides. The file paths here follow the structure of the `third-party-src` submodule, and the files here override the files in `third-party-src` during the build process.
+- `package-lock-overrides`: Contains `package-lock.json` files to keep dependencies in sync with patched `package.json` files. These locally generated files ensure `npm ci` works correctly. They override corresponding files in `third-party-src` during build.
 - `patches`: Patch files created by [Quilt](https://linux.die.net/man/1/quilt), grouped around features.
 - `third-party-src`: Git submodule linking to the upstream [Code-OSS](https://github.com/microsoft/vscode/) commit. The patches are applied on top of this specific commit.
 


### PR DESCRIPTION
*Description of changes:*
- Added explanation note to readme for `package-lock-overrides` folder

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
