### PR TITLE
Added check for new versions of Code OSS

### DIFF
--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -21,7 +21,11 @@ jobs:
         run: |
           cd third-party-src
           git fetch --tags
-          CURRENT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null | head -1 || echo "")
+          CURRENT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null | head -1)
+          if [ -z "$CURRENT_TAG" ]; then
+            echo "Error: Submodule is not on a tagged commit"
+            exit 1
+          fi
           cd ..
           
           LATEST_TAG=$(curl -L \
@@ -43,7 +47,19 @@ jobs:
             echo "Creating staging branch: $STAGING_BRANCH"
             
             git checkout -b "$STAGING_BRANCH"
+            
+            # Update submodule to latest VS Code release
+            echo "Updating submodule to $LATEST_TAG"
+            cd third-party-src
+            git fetch --tags
+            git checkout "$LATEST_TAG"
+            cd ..
+            
+            # Commit the submodule update
+            git add third-party-src
+            git commit -m "Update VS Code submodule to $LATEST_TAG"
+            
             git push origin "$STAGING_BRANCH"
             
-            echo "Created staging branch: $STAGING_BRANCH"
+            echo "Created staging branch: $STAGING_BRANCH with VS Code $LATEST_TAG"
           fi

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -57,6 +57,7 @@ jobs:
             
             echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
             echo "STAGING_BRANCH=$STAGING_BRANCH" >> $GITHUB_ENV
+          fi
             
       - name: Commit and push changes
         uses: EndBug/add-and-commit@v9

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -6,7 +6,44 @@ on:
   workflow_dispatch:
 
 jobs:
-  run:
+  update-automation:
+    name: Run Automation Tasks
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - run: echo "Scheduled job to run automation tasks"
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          
+      - name: Check if update needed
+        run: |
+          cd third-party-src
+          git fetch --tags
+          CURRENT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null | head -1 || echo "")
+          cd ..
+          
+          LATEST_TAG=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/microsoft/vscode/releases/latest | jq -r '.tag_name')
+          
+          echo "Current tag: $CURRENT_TAG"
+          echo "Latest tag: $LATEST_TAG"
+          
+          if [ "$CURRENT_TAG" = "$LATEST_TAG" ]; then
+            echo "Submodule is up to date with latest VS Code release"
+            exit 0
+          else
+            echo "Update needed: $CURRENT_TAG -> $LATEST_TAG"
+            
+            # Create staging branch
+            STAGING_BRANCH="staging-code-editor-$LATEST_TAG"
+            echo "Creating staging branch: $STAGING_BRANCH"
+            
+            git checkout -b "$STAGING_BRANCH"
+            git push origin "$STAGING_BRANCH"
+            
+            echo "Created staging branch: $STAGING_BRANCH"
+          fi

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -30,6 +30,7 @@ jobs:
           
           LATEST_TAG=$(curl -L \
             -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/microsoft/vscode/releases/latest | jq -r '.tag_name')
           

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -55,11 +55,15 @@ jobs:
             git checkout "$LATEST_TAG"
             cd ..
             
-            # Commit the submodule update
-            git add third-party-src
-            git commit -m "Update VS Code submodule to $LATEST_TAG"
+            echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+            echo "STAGING_BRANCH=$STAGING_BRANCH" >> $GITHUB_ENV
             
-            git push origin "$STAGING_BRANCH"
+      - name: Commit and push changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: 'third-party-src'
+          message: 'Update VS Code submodule to ${{ env.LATEST_TAG }}'
+          new_branch: ${{ env.STAGING_BRANCH }}
+          default_author: github_actions
             
-            echo "Created staging branch: $STAGING_BRANCH with VS Code $LATEST_TAG"
-          fi
+    


### PR DESCRIPTION

*Description of changes:*
In the update-automation workflow:
- Added check for new versions of code oss using the github api(https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release).
- In case of new release, create staging branch with name `staging-code-editor-<latest_tag>`.
- Checkout the latest release tag in `third-party-src`, commit and push to the staging branch.
- To determine the current VS Code version in the `third-party-src` submodule, I use `git describe --tags --exact-match HEAD` which grabs the tag associated with the HEAD commit.

*Testing*

Tested the workflow on my fork - https://github.com/vpaiu/code-editor/actions/runs/16937900267.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
