### PR TITLE
Fixed release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,9 +13,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for creating releases
     environment: release-workflow-env
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       COMMIT_SHA: ${{ github.sha }}
       REPOSITORY: ${{ github.repository }}
       VERSION_NUM: ${{ github.event.inputs.version || github.ref_name }}
@@ -90,10 +92,22 @@ jobs:
               \"prerelease\": false
             }")
           
+          echo "Release API response: $RELEASE_RESPONSE"
+          
+          if echo "$RELEASE_RESPONSE" | jq -e '.message' > /dev/null; then
+            echo "Error creating release: $(echo "$RELEASE_RESPONSE" | jq -r '.message')"
+            exit 1
+          fi
+          
           UPLOAD_URL=$(echo "$RELEASE_RESPONSE" | jq -r '.upload_url' | sed 's/{?name,label}//')
           RELEASE_ID=$(echo "$RELEASE_RESPONSE" | jq -r '.id')
-
-          echo UPLOAD_URL $UPLOAD_URL, RELEASE_ID $RELEASE_ID
+          
+          if [ "$UPLOAD_URL" = "null" ] || [ "$RELEASE_ID" = "null" ]; then
+            echo "Failed to extract upload URL or release ID from response"
+            exit 1
+          fi
+          
+          echo "UPLOAD_URL: $UPLOAD_URL, RELEASE_ID: $RELEASE_ID"
           
           # Upload each tar.gz file
           for file in *.tar.gz; do

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,7 +25,6 @@ We use major.minor branches (e.g., `1.0`, `1.1`, `2.1`) for releases.
      git tag 1.0.0
      git push origin 1.0.0
      ```
-   - **GitHub UI**: Go to Releases → Create a new release
    - **GitHub Actions**: Manually run "Create release" workflow from Actions tab
 
 3. **Release notes**: Include code-oss version information in the release description


### PR DESCRIPTION
*Issue #, if available:*
- We had problems releasing a test version: https://github.com/aws/code-editor/actions/runs/16968650258/job/48100126838

*Description of changes:*
- Added logic to fail step with proper error message
- Added permissions for creating release

See failed release run, when permissions are not sufficient: https://github.com/aderende/code-editor/actions/runs/16969827060/job/48103476863
See successful release run, when permissions write exist: https://github.com/aderende/code-editor/actions/runs/16970089950

*Known issues*
- Can't create release on commit that already has existing release. Will be investigated later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
