### PR TITLE
Replace curl with github cli

### DIFF
--- a/.github/workflows/build-targets.yaml
+++ b/.github/workflows/build-targets.yaml
@@ -52,9 +52,7 @@ jobs:
       
       - name: Build artifacts 
         run: |
-          BUILD_TARGET=$(./scripts/determine-build-target.sh ${{ matrix.build-target }})
-          mkdir -p ./$BUILD_TARGET
-          echo "Mock build for ${{ matrix.build-target }}" > ./$BUILD_TARGET/README.txt
+          ./scripts/build-artifacts.sh ${{ matrix.build-target }}
       
       - name: Prepare artifacts to upload
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,6 @@ jobs:
       - name: Download sagemaker artifacts by commit ID
         run: |
           gh run download --name "$COMMIT_SHA-code-editor-sagemaker-server-build" --name "$COMMIT_SHA-code-editor-sagemaker-server-src"
-          ls -la
 
       - name: Check artifacts exist and rename
         run: |
@@ -76,7 +75,7 @@ jobs:
       
       - name: Create GitHub release
         run: |
-          # Check if release already exists
+          # Check if release already exists. Needed when release created via new release in guthub ui
           if gh release view "$VERSION_NUM" > /dev/null 2>&1; then
             echo "Release for tag $VERSION_NUM already exists, uploading additional assets..."
             gh release upload "$VERSION_NUM" *.tar.gz --clobber


### PR DESCRIPTION
*Description of changes:*
- Used gh cli to download artifacts and creating release. Release workflow code is much cleaner.

*Testing*
Created 3 releases with new release workflow by:
- Created new release via Releases -> draft new release (github ui)
  - release workflow: https://github.com/aderende/code-editor/actions/runs/17034606981/job/48284101386
  - release: https://github.com/aderende/code-editor/releases/tag/1.0.15
- Created new release via `git tag 1.0.16 && git push origin 1.0.16`
   - release workflow: https://github.com/aderende/code-editor/actions/runs/17034764269/job/48284601366
   - release: https://github.com/aderende/code-editor/releases/tag/1.0.16
- Created new release via manual execution of release workflow
  - release workflow: https://github.com/aderende/code-editor/actions/runs/17035422555/job/48286663620
  - release: https://github.com/aderende/code-editor/releases/tag/1.0.17

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
