### PR TITLE
Added error handling

### DIFF
--- a/.github/workflows/build-targets.yaml
+++ b/.github/workflows/build-targets.yaml
@@ -97,6 +97,6 @@ jobs:
         run: |
           aws cloudwatch put-metric-data \
             --namespace "GitHub/Workflows" \
-            --metric-name "WorkflowExecution" \
-            --dimensions "Repository=${{ env.REPOSITORY }},Workflow=BuildTargets,Status=Failed" \
+            --metric-name "ExecutionsFailed" \
+            --dimensions "Repository=${{ env.REPOSITORY }},Workflow=BuildTargets" \
             --value 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,6 +106,6 @@ jobs:
         run: |
           aws cloudwatch put-metric-data \
             --namespace "GitHub/Workflows" \
-            --metric-name "WorkflowExecution" \
-            --dimensions "Repository=${{ env.REPOSITORY }},Workflow=Release,Status=Failed" \
+            --metric-name "ExecutionsFailed" \
+            --dimensions "Repository=${{ env.REPOSITORY }},Workflow=Release" \
             --value 1


### PR DESCRIPTION
*Description of changes:*
- Added sending failure metrics to git hub prod account

`handle-failures` jobs use unique `environment` per workflow
Production github roles can be used only in aws/code-editor repository and unique for each workflow. 

in fork repository `handle-failures` always succeed and not send metric because
- `Use role credentials for metrics` fails, but job continues `continue-on-error: ${{ env.REPOSITORY != 'aws/code-editor' }}`
- `Report failure` is skipped, because it has condition `if: steps.aws-creds.outcome == 'success'`

in original repository `handle-failures` succeed and send metric when
- `Use role credentials for metrics` succeed
- `Report failure` is executed, because it has condition `if: steps.aws-creds.outcome == 'success'`

if role were not assumed correctly in original repository, `handle-failures` job fails because
- `Use role credentials for metrics` fails and job end with error, second step is not started `continue-on-error: ${{ env.REPOSITORY != 'aws/code-editor' }}`

*Testing*
- created testing role for fork repo and emitted metric https://github.com/aderende/code-editor/actions/runs/17070678172

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
