### PR TITLE
Inject updated Code Editor Version into release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,10 +82,16 @@ jobs:
 
           # Update Code Editor Version in all files
           jq ".codeEditorVersion = \"$VERSION_NUM\"" product.json > temp.json && mv temp.json product.json
-          sed -i "s/codeEditorVersion:\s*\"$CURRENT_VERSION\"/codeEditorVersion:\"$VERSION_NUM\"/g" out/server-main.js
-          sed -i "s/codeEditorVersion:\s*\"$CURRENT_VERSION\"/codeEditorVersion:\"$VERSION_NUM\"/g" out/vs/code/browser/workbench/workbench.js
-          sed -i "s/codeEditorVersion:\s*\"$CURRENT_VERSION\"/codeEditorVersion:\"$VERSION_NUM\"/g" out/vs/platform/terminal/node/ptyHostMain.js
-          sed -i "s/codeEditorVersion:\s*\"$CURRENT_VERSION\"/codeEditorVersion:\"$VERSION_NUM\"/g" out/vs/workbench/api/node/extensionHostProcess.js
+          
+          FILES_TO_UPDATE=(
+            "out/server-main.js"
+            "out/vs/code/browser/workbench/workbench.js"
+            "out/vs/platform/terminal/node/ptyHostMain.js"
+            "out/vs/workbench/api/node/extensionHostProcess.js"
+          )
+          for file in "${FILES_TO_UPDATE[@]}"; do
+            sed -i "s/codeEditorVersion:\s*\"$CURRENT_VERSION\"/codeEditorVersion:\"$VERSION_NUM\"/g" "$file"
+          done
 
           cd ..
           tar -czf "code-editor-sagemaker-server-$VERSION_NUM.tar.gz" vscode-reh-web-linux-x64/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
             fi
           done
 
-      - name: Untar, Inject current Code Editor Version and Re-tar
+      - name: Verify Code Editor version in product.json
         run: |
           tar xzf "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-build/$SAGEMAKER_ARTIFACT_PREFIX-build.tar.gz"
           cd vscode-reh-web-linux-x64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
       COMMIT_SHA: ${{ github.sha }}
       REPOSITORY: ${{ github.repository }}
       VERSION_NUM: ${{ github.event.inputs.version || github.ref_name }}
+      SAGEMAKER_ARTIFACT_PREFIX: "code-editor-sagemaker-server"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -53,8 +54,13 @@ jobs:
         run: |
           ls -la
 
+          FILES=(
+            "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-build/$SAGEMAKER_ARTIFACT_PREFIX-build.tar.gz"
+            "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-src/$SAGEMAKER_ARTIFACT_PREFIX-src.tar.gz"
+          )
+          
           # Check build artifact exists
-          for file in "$COMMIT_SHA-code-editor-sagemaker-server-build.tar.gz" "$COMMIT_SHA-code-editor-sagemaker-server-src.tar.gz"; do
+          for file in "${FILES[@]}"; do
             if [ ! -f "$file" ]; then
               echo "Error: $file not found for commit $COMMIT_SHA"
               exit 1
@@ -63,16 +69,18 @@ jobs:
 
       - name: Untar, Inject current Code Editor Version and Re-tar
         run: |
-          tar xzf $COMMIT_SHA-code-editor-sagemaker-server-build.tar.gz
+          tar xzf "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-build/$SAGEMAKER_ARTIFACT_PREFIX-build.tar.gz"
           cd vscode-reh-web-linux-x64
           jq '.codeEditorVersion = "$VERSION_NUM"' product.json > temp.json && mv temp.json product.json
-          tar -czf code-editor-sagemaker-server-${VERSION_NUM}.tar.gz vscode-reh-web-linux-x64
+          cd ..
+          tar -czf "code-editor-sagemaker-server-$VERSION_NUM.tar.gz" vscode-reh-web-linux-x64/
           rm -rf vscode-reh-web-linux-x64
 
-          tar xzf $COMMIT_SHA-code-editor-sagemaker-server-src.tar.gz
+          tar xzf "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-src/$SAGEMAKER_ARTIFACT_PREFIX-src.tar.gz"
           cd code-editor-src
           jq '.codeEditorVersion = "$VERSION_NUM"' product.json > temp.json && mv temp.json product.json
-          tar -czf code-editor-sagemaker-src-${VERSION_NUM}.tar.gz code-editor-src
+          cd ..
+          tar -czf "code-editor-sagemaker-src-$VERSION_NUM.tar.gz" code-editor-src/
           rm -rf code-editor-src
       
       - name: Create GitHub release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,14 +71,14 @@ jobs:
         run: |
           tar xzf "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-build/$SAGEMAKER_ARTIFACT_PREFIX-build.tar.gz"
           cd vscode-reh-web-linux-x64
-          jq '.codeEditorVersion = "$VERSION_NUM"' product.json > temp.json && mv temp.json product.json
+          jq ".codeEditorVersion = \"$VERSION_NUM\"" product.json > temp.json && mv temp.json product.json
           cd ..
           tar -czf "code-editor-sagemaker-server-$VERSION_NUM.tar.gz" vscode-reh-web-linux-x64/
           rm -rf vscode-reh-web-linux-x64
 
           tar xzf "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-src/$SAGEMAKER_ARTIFACT_PREFIX-src.tar.gz"
           cd code-editor-src
-          jq '.codeEditorVersion = "$VERSION_NUM"' product.json > temp.json && mv temp.json product.json
+          jq ".codeEditorVersion = \"$VERSION_NUM\"" product.json > temp.json && mv temp.json product.json
           cd ..
           tar -czf "code-editor-sagemaker-src-$VERSION_NUM.tar.gz" code-editor-src/
           rm -rf code-editor-src

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,29 +49,31 @@ jobs:
         run: |
           gh run download --name "$COMMIT_SHA-code-editor-sagemaker-server-build" --name "$COMMIT_SHA-code-editor-sagemaker-server-src"
 
-      - name: Check artifacts exist and rename
+      - name: Check artifacts exist
         run: |
           ls -la
-          
-          # Rename build artifact
-          BUILD_TARBALL=$(find . -name "*build*.tar.gz" | head -1 || true)
-          if [ -n "$BUILD_TARBALL" ]; then
-            cp "$BUILD_TARBALL" "code-editor-sagemaker-${VERSION_NUM}.tar.gz"
-            echo "Copied $BUILD_TARBALL to code-editor-sagemaker-${VERSION_NUM}.tar.gz"
-          else
-            echo "Error: No build artifacts found for commit $COMMIT_SHA"
-            exit 1
-          fi
-          
-          # Rename src artifact
-          SRC_TARBALL=$(find . -name "*src*.tar.gz" | head -1 || true)
-          if [ -n "$SRC_TARBALL" ]; then
-            cp "$SRC_TARBALL" "code-editor-sagemaker-src-${VERSION_NUM}.tar.gz"
-            echo "Copied $SRC_TARBALL to code-editor-sagemaker-src-${VERSION_NUM}.tar.gz"
-          else
-            echo "Error: No src artifacts found for commit $COMMIT_SHA"
-            exit 1
-          fi
+
+          # Check build artifact exists
+          for file in "code-editor-sagemaker-server-build.tar.gz" "code-editor-sagemaker-server-src.tar.gz"; do
+            if [ ! -f "$file" ]; then
+              echo "Error: $file not found for commit $COMMIT_SHA"
+              exit 1
+            fi
+          done
+
+      - name: Untar, Inject current Code Editor Version and Re-tar
+        run: |
+          tar xzf code-editor-sagemaker-server-build.tar.gz
+          cd vscode-reh-web-linux-x64
+          jq '.codeEditorVersion = "$VERSION_NUM"' product.json > temp.json && mv temp.json product.json
+          tar -czf code-editor-sagemaker-server-${VERSION_NUM}.tar.gz vscode-reh-web-linux-x64
+          rm -rf vscode-reh-web-linux-x64
+
+          tar xzf code-editor-sagemaker-server-src.tar.gz
+          cd code-editor-src
+          jq '.codeEditorVersion = "$VERSION_NUM"' product.json > temp.json && mv temp.json product.json
+          tar -czf code-editor-sagemaker-src-${VERSION_NUM}.tar.gz code-editor-src
+          rm -rf code-editor-src
       
       - name: Create GitHub release
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Verify Code Editor version in product.json
         run: |
+          echo "Running verification step"
           tar xzf "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-build/$SAGEMAKER_ARTIFACT_PREFIX-build.tar.gz"
           cd vscode-reh-web-linux-x64
           jq ".codeEditorVersion = \"$VERSION_NUM\"" product.json > temp.json && mv temp.json product.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,22 +67,29 @@ jobs:
             fi
           done
 
-      - name: Verify Code Editor version in product.json
+      - name: Update Code Editor version
         run: |
-          echo "Running verification step"
-          tar xzf "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-build/$SAGEMAKER_ARTIFACT_PREFIX-build.tar.gz"
-          cd vscode-reh-web-linux-x64
-          jq ".codeEditorVersion = \"$VERSION_NUM\"" product.json > temp.json && mv temp.json product.json
-          cd ..
-          tar -czf "code-editor-sagemaker-server-$VERSION_NUM.tar.gz" vscode-reh-web-linux-x64/
-          rm -rf vscode-reh-web-linux-x64
-
           tar xzf "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-src/$SAGEMAKER_ARTIFACT_PREFIX-src.tar.gz"
           cd code-editor-src
+          CURRENT_VERSION=$(jq -r '.codeEditorVersion' product.json)
           jq ".codeEditorVersion = \"$VERSION_NUM\"" product.json > temp.json && mv temp.json product.json
           cd ..
           tar -czf "code-editor-sagemaker-src-$VERSION_NUM.tar.gz" code-editor-src/
           rm -rf code-editor-src
+          
+          tar xzf "$COMMIT_SHA-$SAGEMAKER_ARTIFACT_PREFIX-build/$SAGEMAKER_ARTIFACT_PREFIX-build.tar.gz"
+          cd vscode-reh-web-linux-x64
+
+          # Update Code Editor Version in all files
+          jq ".codeEditorVersion = \"$VERSION_NUM\"" product.json > temp.json && mv temp.json product.json
+          sed -i "s/codeEditorVersion:\s*\"$CURRENT_VERSION\"/codeEditorVersion:\"$VERSION_NUM\"/g" out/server-main.js
+          sed -i "s/codeEditorVersion:\s*\"$CURRENT_VERSION\"/codeEditorVersion:\"$VERSION_NUM\"/g" out/vs/code/browser/workbench/workbench.js
+          sed -i "s/codeEditorVersion:\s*\"$CURRENT_VERSION\"/codeEditorVersion:\"$VERSION_NUM\"/g" out/vs/platform/terminal/node/ptyHostMain.js
+          sed -i "s/codeEditorVersion:\s*\"$CURRENT_VERSION\"/codeEditorVersion:\"$VERSION_NUM\"/g" out/vs/workbench/api/node/extensionHostProcess.js
+
+          cd ..
+          tar -czf "code-editor-sagemaker-server-$VERSION_NUM.tar.gz" vscode-reh-web-linux-x64/
+          rm -rf vscode-reh-web-linux-x64
       
       - name: Create GitHub release
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
           ls -la
 
           # Check build artifact exists
-          for file in "code-editor-sagemaker-server-build.tar.gz" "code-editor-sagemaker-server-src.tar.gz"; do
+          for file in "$COMMIT_SHA-code-editor-sagemaker-server-build.tar.gz" "$COMMIT_SHA-code-editor-sagemaker-server-src.tar.gz"; do
             if [ ! -f "$file" ]; then
               echo "Error: $file not found for commit $COMMIT_SHA"
               exit 1
@@ -63,13 +63,13 @@ jobs:
 
       - name: Untar, Inject current Code Editor Version and Re-tar
         run: |
-          tar xzf code-editor-sagemaker-server-build.tar.gz
+          tar xzf $COMMIT_SHA-code-editor-sagemaker-server-build.tar.gz
           cd vscode-reh-web-linux-x64
           jq '.codeEditorVersion = "$VERSION_NUM"' product.json > temp.json && mv temp.json product.json
           tar -czf code-editor-sagemaker-server-${VERSION_NUM}.tar.gz vscode-reh-web-linux-x64
           rm -rf vscode-reh-web-linux-x64
 
-          tar xzf code-editor-sagemaker-server-src.tar.gz
+          tar xzf $COMMIT_SHA-code-editor-sagemaker-server-src.tar.gz
           cd code-editor-src
           jq '.codeEditorVersion = "$VERSION_NUM"' product.json > temp.json && mv temp.json product.json
           tar -czf code-editor-sagemaker-src-${VERSION_NUM}.tar.gz code-editor-src

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ The repository structure is the following:
 - `patches`: Patch files created by [Quilt](https://linux.die.net/man/1/quilt), grouped around features.
 - `third-party-src`: Git submodule linking to the upstream [Code-OSS](https://github.com/microsoft/vscode/) commit. The patches are applied on top of this specific commit.
 
+## Creating a new release
+
+A new release will be automatically created when a new tag is published. The following are the steps to publish a new tag
+1. Checkout the branch locally on which you need to publish the new tag.
+1. Create a new tag locally using the command `git tag -a 2.0.1 commitHash -m "tag message"`
+1. Push the tag to GitHub using `git push origin 2.0.1`.
+1. This will create a new tag and will automatically start the release workflow for publishing a new release.
+
 ## Troubleshooting and Feedback
 
 See [CONTRIBUTING](CONTRIBUTING.md#reporting-bugsfeature-requests) for more information.


### PR DESCRIPTION
## Description of changes:

This change updates the Release Workflow to inject the current Code Editor Version into the release artifacts.
For the code-editor-sagemaker-server distribution, the version has to be injected into the following files:
1. product.json
2. out/server-main.js
1. out/vs/code/browser/workbench/workbench.js
1. out/vs/platform/terminal/node/ptyHostMain.js
1. out/vs/workbench/api/node/extensionHostProcess.js

For the code-editor-sagemaker-src patched source, the version has to be injected into just the product.json file.

## Testing

1. Verified that the release workflow works as expected by creating a new release 2.0.1, link to the new release: https://github.com/aws/code-editor/releases/tag/2.0.1
2. Verified that the code-editor-sagemaker-server distribution from the release artifacts shows the correct Code Editor Version in "Help > About"
<img width="524" height="303" alt="Screenshot 2025-08-20 at 13 26 31" src="https://github.com/user-attachments/assets/9b696345-d252-43bd-93f4-24fbb42cfd6c" />





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
