### PR TITLE
Removed workflow_dispatch to prohibit manual invocation

### DIFF
--- a/.github/workflows/build-targets.yaml
+++ b/.github/workflows/build-targets.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - 'main'
       - '*.*'
-  workflow_dispatch:
   
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,5 @@
 name: Create release
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Release version'
-        required: true
-        type: string
   push:
     tags:
       - '*'


### PR DESCRIPTION
*Description of changes:*
- Removed `workflow_dispatch` to prohibit workflow triggered manually

*Testing*
- See workflows can't be triggered manually: https://github.com/aderende/code-editor/actions/workflows/release.yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
