### PR TITLE
Add step for regenerating OSS attribution in the update-automation workflow

### DIFF
--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -221,6 +221,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Setup environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+          npm i -g license-checker
           
       - name: Checkout code
         uses: actions/checkout@v4
@@ -258,7 +263,6 @@ jobs:
           
       - name: Generate unified OSS attribution
         run: |
-          npm i -g license-checker
           chmod +x ./scripts/generate-oss-attribution.sh
           ./scripts/generate-oss-attribution.sh --command generate_unified_oss_attribution
           

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -154,11 +154,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y quilt libxml2-utils jq libx11-dev libxkbfile-dev
           
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -199,7 +194,7 @@ jobs:
       - name: Upload prepared source as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}-prepared-source-${{ matrix.target }}
+          name: ${{ github.run_id }}-prepared-source-${{ matrix.target }}
           path: code-editor-src/
           retention-days: 1
           
@@ -226,15 +221,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Setup environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y quilt libxml2-utils jq libx11-dev libxkbfile-dev
-          
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
           
       - name: Checkout code
         uses: actions/checkout@v4
@@ -255,14 +241,14 @@ jobs:
       - name: Download prepared sources from artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ github.sha }}-prepared-source-*
+          pattern: ${{ github.run_id }}-prepared-source-*
           merge-multiple: false
           
       - name: Organize downloaded sources
         run: |
           for target in code-editor-server code-editor-sagemaker-server code-editor-web-embedded code-editor-web-embedded-with-terminal; do
-            if [[ -d "${{ github.sha }}-prepared-source-$target" ]]; then
-              mv "${{ github.sha }}-prepared-source-$target" "code-editor-src-$target"
+            if [[ -d "${{ github.run_id }}-prepared-source-$target" ]]; then
+              mv "${{ github.run_id }}-prepared-source-$target" "code-editor-src-$target"
               echo "Organized prepared source for $target"
             else
               echo "Missing prepared source artifact for target: $target"

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -143,6 +143,16 @@ jobs:
           npm i -g license-checker
           chmod +x ./scripts/generate-oss-attribution.sh
           ./scripts/generate-oss-attribution.sh --command generate_unified_oss_attribution
+          
+          # Copy LICENSE-THIRD-PARTY to root directory
+          cp overrides/LICENSE-THIRD-PARTY LICENSE-THIRD-PARTY
+          
+          # Commit OSS attribution if any changes
+          git add overrides/ LICENSE-THIRD-PARTY
+          if ! git diff --staged --quiet; then
+            git commit -m "Update OSS attribution"
+            git push origin "$STAGING_BRANCH"
+          fi
 
   update-package-locks:
     name: Update Package Locks

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -198,12 +198,13 @@ jobs:
             fi
           done
           
-          # Move prepared source to target-specific directory and commit
+          # Move prepared source to target-specific directory
           mv code-editor-src "code-editor-src-${{ matrix.target }}"
           
       - name: Commit package-lock overrides and prepared source
         run: |
-          git add package-lock-overrides/ "code-editor-src-${{ matrix.target }}"
+          git add package-lock-overrides/
+          git add --force "code-editor-src-${{ matrix.target }}"
           if ! git diff --staged --quiet; then
             git commit -m "Update package-lock.json overrides and prepared source for ${{ matrix.target }}"
             
@@ -239,7 +240,11 @@ jobs:
         with:
           ref: ${{ needs.update-automation.outputs.staging-branch }}
           fetch-depth: 0
-          submodules: true
+          submodules: false
+          
+      - name: Initialize only third-party-src submodule
+        run: |
+          git submodule update --init third-party-src
           
       - name: Configure git
         run: |

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -18,7 +18,7 @@ jobs:
         run: |
           echo "Installing required dependencies"
           sudo apt-get update
-          sudo apt-get install -y quilt libxml2-utils jq libx11-dev
+          sudo apt-get install -y quilt libxml2-utils jq libx11-dev libxkbfile-dev
           
       - name: Checkout code
         uses: actions/checkout@v4
@@ -141,6 +141,7 @@ jobs:
       - name: Generate OSS attribution
         run: |
           npm i -g license-checker
+          chmod +x ./scripts/generate-oss-attribution.sh
           ./scripts/generate-oss-attribution.sh --command generate_unified_oss_attribution
 
   update-package-locks:
@@ -157,7 +158,7 @@ jobs:
       - name: Setup environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y quilt libxml2-utils jq libx11-dev
+          sudo apt-get install -y quilt libxml2-utils jq libx11-dev libxkbfile-dev
           
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -259,7 +259,6 @@ jobs:
           
       - name: Generate unified OSS attribution
         run: |
-          chmod +x ./scripts/generate-oss-attribution.sh
           ./scripts/generate-oss-attribution.sh --command generate_unified_oss_attribution
           
       - name: Commit OSS attribution

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -18,7 +18,7 @@ jobs:
         run: |
           echo "Installing required dependencies"
           sudo apt-get update
-          sudo apt-get install -y quilt libxml2-utils jq libx11-dev libxkbfile-dev
+          sudo apt-get install -y quilt libxml2-utils jq
           
       - name: Checkout code
         uses: actions/checkout@v4
@@ -137,8 +137,6 @@ jobs:
             git commit -m "Rebase patches for all targets"
             git push origin "$STAGING_BRANCH"
           fi
-          
-
 
   update-package-locks:
     name: Update Package Locks
@@ -198,15 +196,18 @@ jobs:
             fi
           done
           
-          # Move prepared source to target-specific directory
-          mv code-editor-src "code-editor-src-${{ matrix.target }}"
+      - name: Upload prepared source as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.sha }}-prepared-source-${{ matrix.target }}
+          path: code-editor-src/
+          retention-days: 1
           
-      - name: Commit package-lock overrides and prepared source
+      - name: Commit package-lock overrides
         run: |
           git add package-lock-overrides/
-          git add --force "code-editor-src-${{ matrix.target }}"
           if ! git diff --staged --quiet; then
-            git commit -m "Update package-lock.json overrides and prepared source for ${{ matrix.target }}"
+            git commit -m "Update package-lock.json overrides for ${{ matrix.target }}"
             
             # Retry push with rebase until successful
             for i in {1..5}; do
@@ -251,22 +252,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
-      - name: Verify prepared sources exist
+      - name: Download prepared sources from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ github.sha }}-prepared-source-*
+          merge-multiple: false
+          
+      - name: Organize downloaded sources
         run: |
-          MISSING_TARGETS=()
           for target in code-editor-server code-editor-sagemaker-server code-editor-web-embedded code-editor-web-embedded-with-terminal; do
-            if [[ ! -d "code-editor-src-$target" ]]; then
-              echo "Missing prepared source for target: $target"
-              MISSING_TARGETS+=("$target")
+            if [[ -d "${{ github.sha }}-prepared-source-$target" ]]; then
+              mv "${{ github.sha }}-prepared-source-$target" "code-editor-src-$target"
+              echo "Organized prepared source for $target"
             else
-              echo "Found prepared source for target: $target"
+              echo "Missing prepared source artifact for target: $target"
+              exit 1
             fi
           done
-          
-          if [[ ${#MISSING_TARGETS[@]} -gt 0 ]]; then
-            echo "Missing prepared sources for targets: ${MISSING_TARGETS[*]}"
-            exit 1
-          fi
           
       - name: Generate unified OSS attribution
         run: |
@@ -288,11 +290,7 @@ jobs:
       - name: Clean up prepared source directories
         run: |
           rm -rf code-editor-src-*
-          git add -A
-          if ! git diff --staged --quiet; then
-            git commit -m "Clean up prepared source directories"
-            git push origin "${{ needs.update-automation.outputs.staging-branch }}"
-          fi
+          echo "Cleaned up local prepared source directories"
           
   handle-failures:
     name: Handle Failures
@@ -304,5 +302,3 @@ jobs:
         run: |
           # TODO: Implement metric reporting to CW.
           exit 1
-            
-    

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -138,21 +138,7 @@ jobs:
             git push origin "$STAGING_BRANCH"
           fi
           
-      - name: Generate OSS attribution
-        run: |
-          npm i -g license-checker
-          chmod +x ./scripts/generate-oss-attribution.sh
-          ./scripts/generate-oss-attribution.sh --command generate_unified_oss_attribution
-          
-          # Copy LICENSE-THIRD-PARTY to root directory
-          cp overrides/LICENSE-THIRD-PARTY LICENSE-THIRD-PARTY
-          
-          # Commit OSS attribution if any changes
-          git add overrides/ LICENSE-THIRD-PARTY
-          if ! git diff --staged --quiet; then
-            git commit -m "Update OSS attribution"
-            git push origin "$STAGING_BRANCH"
-          fi
+
 
   update-package-locks:
     name: Update Package Locks
@@ -169,6 +155,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y quilt libxml2-utils jq libx11-dev libxkbfile-dev
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
           
       - name: Checkout code
         uses: actions/checkout@v4
@@ -207,13 +198,14 @@ jobs:
             fi
           done
           
-          rm -rf code-editor-src
+          # Move prepared source to target-specific directory and commit
+          mv code-editor-src "code-editor-src-${{ matrix.target }}"
           
-      - name: Commit package-lock overrides
+      - name: Commit package-lock overrides and prepared source
         run: |
-          git add package-lock-overrides/
+          git add package-lock-overrides/ "code-editor-src-${{ matrix.target }}"
           if ! git diff --staged --quiet; then
-            git commit -m "Update package-lock.json overrides for ${{ matrix.target }}"
+            git commit -m "Update package-lock.json overrides and prepared source for ${{ matrix.target }}"
             
             # Retry push with rebase until successful
             for i in {1..5}; do
@@ -223,11 +215,84 @@ jobs:
               sleep $((i * 2))
             done
           fi
+
+  generate-oss-attribution:
+    name: Generate OSS Attribution
+    runs-on: ubuntu-latest
+    needs: [update-automation, update-package-locks]
+    if: needs.update-automation.outputs.staging-branch != ''
+    permissions:
+      contents: write
+    steps:
+      - name: Setup environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y quilt libxml2-utils jq libx11-dev libxkbfile-dev
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.update-automation.outputs.staging-branch }}
+          fetch-depth: 0
+          submodules: true
+          
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+      - name: Verify prepared sources exist
+        run: |
+          MISSING_TARGETS=()
+          for target in code-editor-server code-editor-sagemaker-server code-editor-web-embedded code-editor-web-embedded-with-terminal; do
+            if [[ ! -d "code-editor-src-$target" ]]; then
+              echo "Missing prepared source for target: $target"
+              MISSING_TARGETS+=("$target")
+            else
+              echo "Found prepared source for target: $target"
+            fi
+          done
+          
+          if [[ ${#MISSING_TARGETS[@]} -gt 0 ]]; then
+            echo "Missing prepared sources for targets: ${MISSING_TARGETS[*]}"
+            exit 1
+          fi
+          
+      - name: Generate unified OSS attribution
+        run: |
+          npm i -g license-checker
+          chmod +x ./scripts/generate-oss-attribution.sh
+          ./scripts/generate-oss-attribution.sh --command generate_unified_oss_attribution
+          
+      - name: Commit OSS attribution
+        run: |
+          # Copy LICENSE-THIRD-PARTY to root directory
+          cp overrides/LICENSE-THIRD-PARTY LICENSE-THIRD-PARTY
+          
+          git add overrides/ LICENSE-THIRD-PARTY
+          if ! git diff --staged --quiet; then
+            git commit -m "Update unified OSS attribution"
+            git push origin "${{ needs.update-automation.outputs.staging-branch }}"
+          fi
+          
+      - name: Clean up prepared source directories
+        run: |
+          rm -rf code-editor-src-*
+          git add -A
+          if ! git diff --staged --quiet; then
+            git commit -m "Clean up prepared source directories"
+            git push origin "${{ needs.update-automation.outputs.staging-branch }}"
+          fi
           
   handle-failures:
     name: Handle Failures
     runs-on: ubuntu-latest
-    needs: [update-automation, update-package-locks]
+    needs: [update-automation, update-package-locks, generate-oss-attribution]
     if: failure()
     steps:
       - name: Report rebase failures

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -18,7 +18,7 @@ jobs:
         run: |
           echo "Installing required dependencies"
           sudo apt-get update
-          sudo apt-get install -y quilt libxml2-utils jq libkrb5-dev libx11-dev libxkbfile-dev
+          sudo apt-get install -y quilt libxml2-utils jq libx11-dev
           
       - name: Checkout code
         uses: actions/checkout@v4
@@ -137,6 +137,11 @@ jobs:
             git commit -m "Rebase patches for all targets"
             git push origin "$STAGING_BRANCH"
           fi
+          
+      - name: Generate OSS attribution
+        run: |
+          npm i -g license-checker
+          ./scripts/generate-oss-attribution.sh --command generate_unified_oss_attribution
 
   update-package-locks:
     name: Update Package Locks
@@ -152,7 +157,7 @@ jobs:
       - name: Setup environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y quilt libxml2-utils jq libkrb5-dev libx11-dev libxkbfile-dev
+          sudo apt-get install -y quilt libxml2-utils jq libx11-dev
           
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -232,11 +232,7 @@ jobs:
         with:
           ref: ${{ needs.update-automation.outputs.staging-branch }}
           fetch-depth: 0
-          submodules: false
-          
-      - name: Initialize only third-party-src submodule
-        run: |
-          git submodule update --init third-party-src
+          submodules: true
           
       - name: Configure git
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ build-artifacts
 build-private
 code-editor-src
 vscode-reh-web-*
-code-editor-src-*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build-artifacts
 build-private
 code-editor-src
 vscode-reh-web-*
+code-editor-src-*

--- a/build-tools/oss-attribution/additional-third-party-licenses.txt
+++ b/build-tools/oss-attribution/additional-third-party-licenses.txt
@@ -1,0 +1,23 @@
+code-server v4.91.1
+https://github.com/coder/code-server
+
+The MIT License
+
+Copyright (c) 2019 Coder Technologies Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/build-tools/oss-attribution/excluded-packages.json
+++ b/build-tools/oss-attribution/excluded-packages.json
@@ -1,0 +1,4 @@
+{
+  "code-oss-dev@1.101.0": "UNLICENSED",
+  "jschardet@3.1.4": "LGPL-2.1+"
+}

--- a/build-tools/oss-attribution/excluded-packages.json
+++ b/build-tools/oss-attribution/excluded-packages.json
@@ -1,4 +1,4 @@
 {
   "code-oss-dev@1.101.0": "UNLICENSED",
-  "jschardet@3.1.4": "LGPL-2.1+"
+  "jschardet@3.1.4": "LGPL-2.1-or-later"
 }

--- a/build-tools/oss-attribution/excluded-packages.txt
+++ b/build-tools/oss-attribution/excluded-packages.txt
@@ -1,0 +1,2 @@
+code-oss-dev@1.101.0
+jschardet@3.1.4

--- a/build-tools/oss-attribution/excluded-packages.txt
+++ b/build-tools/oss-attribution/excluded-packages.txt
@@ -1,2 +1,0 @@
-code-oss-dev@1.101.0
-jschardet@3.1.4

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -85,23 +85,41 @@ generate_unified_oss_attribution() {
     local targets=("code-editor-server" "code-editor-sagemaker-server" "code-editor-web-embedded" "code-editor-web-embedded-with-terminal")
     local target_dirs=()
     
-    # Prepare source for each target in separate directories
+    if [[ "$PREPARE_SOURCES" == "true" ]]; then
+        echo "Preparing sources from scratch"
+        for target in "${targets[@]}"; do
+            echo "Preparing source for $target"
+            
+            "$ROOT_DIR/scripts/prepare-src.sh" "$target"
+            mv "$ROOT_DIR/code-editor-src" "$ROOT_DIR/code-editor-src-$target"
+            cd "$ROOT_DIR/code-editor-src-$target"
+            npm install
+            cd "$ROOT_DIR"
+            
+            target_dirs+=("$ROOT_DIR/code-editor-src-$target")
+        done
+    else
+        # Check that all target directories exist
+        local missing_targets=()
+        for target in "${targets[@]}"; do
+            if [[ -d "$ROOT_DIR/code-editor-src-$target" ]]; then
+                echo "Found existing prepared source for $target"
+                target_dirs+=("$ROOT_DIR/code-editor-src-$target")
+            else
+                missing_targets+=("$target")
+            fi
+        done
+        
+        if [[ ${#missing_targets[@]} -gt 0 ]]; then
+            echo "Error: Missing prepared source directories for targets: ${missing_targets[*]}" >&2
+            echo "Use --prepare-sources flag to prepare sources automatically" >&2
+            exit 1
+        fi
+    fi
+    
+    # Check licenses for all targets
     for target in "${targets[@]}"; do
-        echo "Preparing source for $target"
-        
-        # Prepare source for this target
-        "$ROOT_DIR/scripts/prepare-src.sh" "$target"
-        
-        # Move to target-specific directory
-        mv "$ROOT_DIR/code-editor-src" "$ROOT_DIR/code-editor-src-$target"
-        cd "$ROOT_DIR/code-editor-src-$target"
-        npm config set cache "$ROOT_DIR/.npm-cache" --global
-        npm install
-        cd "$ROOT_DIR"
-        
         check_unapproved_licenses "$target" "$ROOT_DIR/code-editor-src-$target"
-        
-        target_dirs+=("$ROOT_DIR/code-editor-src-$target")
     done
     
     # Generate unified OSS attribution using multiple base directories
@@ -137,35 +155,49 @@ $additional_third_party_licenses
 $attribution_licenses
 EOF
     
-    # Clean up target directories
-    rm -rf "$ROOT_DIR/code-editor-src-"*
+    # Only clean up if we prepared the sources in this run
+    if [[ "$PREPARE_SOURCES" == "true" ]]; then
+        rm -rf "$ROOT_DIR/code-editor-src-"*
+    fi
 }
 
 # Parse command line arguments
 COMMAND="generate_oss_attribution"
 OUTPUT_DIR="$ROOT_DIR/overrides"
+PREPARE_SOURCES=false
+TARGET="code-editor-server"
 
-case "${1:-}" in
-    --command)
-        [[ $# -ge 2 ]] || { echo "--command requires a value" >&2; exit 1; }
-        COMMAND="$2"
-        OUTPUT_DIR="${3:-$OUTPUT_DIR}"
-        ;;
-    --*)
-        echo "Unknown option $1" >&2
-        exit 1
-        ;;
-    "")
-        # No arguments, use defaults
-        ;;
-    *)
-        OUTPUT_DIR="$1"
-        ;;
-esac
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --command)
+            COMMAND="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --target)
+            TARGET="$2"
+            shift 2
+            ;;
+        --prepare-sources)
+            PREPARE_SOURCES=true
+            shift
+            ;;
+        --*)
+            echo "Unknown option $1" >&2
+            exit 1
+            ;;
+        *)
+            OUTPUT_DIR="$1"
+            shift
+            ;;
+    esac
+done
 
 case "$COMMAND" in
     generate_oss_attribution)
-        TARGET="${4:-code-editor-server}"
         generate_oss_attribution "$OUTPUT_DIR" "$TARGET"
         ;;
     generate_unified_oss_attribution)

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -57,8 +57,7 @@ check_unapproved_licenses() {
     
     local output
     if [[ -n "$excluded_packages" ]]; then
-        excluded_packages="'$excluded_packages'"
-        output=$(cd "$src_dir" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages "$excluded_packages" 2>/dev/null || true)
+        output=$(cd "$src_dir" && eval "license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages '$excluded_packages'" 2>/dev/null || true)   
     else
         output=$(cd "$src_dir" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD 2>/dev/null || true)
     fi

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -57,7 +57,8 @@ check_unapproved_licenses() {
     
     local output
     if [[ -n "$excluded_packages" ]]; then
-        output=$(cd "$src_dir" && eval "license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages '$excluded_packages'" 2>/dev/null || true)
+        excluded_packages="'$excluded_packages'"
+        output=$(cd "$src_dir" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages "$excluded_packages" 2>/dev/null || true)
     else
         output=$(cd "$src_dir" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD 2>/dev/null || true)
     fi
@@ -92,7 +93,7 @@ generate_oss_attribution() {
         check_unapproved_licenses "$target" "$BUILD_SRC_DIR"
     fi
 
-    npx --yes --package @electrovir/oss-attribution-generator -- generate-attribution --baseDir "$BUILD_SRC_DIR" --outputDir "$oss_attribution_dir"
+    npx --yes --package @electrovir/oss-attribution-generator@2.0.0 -- generate-attribution --baseDir "$BUILD_SRC_DIR" --outputDir "$oss_attribution_dir"
     attribution_licenses=$(cat "$oss_attribution_dir/attribution.txt")
 
     read_status=0
@@ -167,7 +168,7 @@ generate_unified_oss_attribution() {
     echo "Generating unified OSS attribution for all targets"
     mkdir -p "$BUILD_DIR/private/oss-attribution"
     
-    npx --yes --package @electrovir/oss-attribution-generator -- generate-attribution \
+    npx --yes --package @electrovir/oss-attribution-generator@2.0.0 -- generate-attribution \
         -b "${target_dirs[0]}" "${target_dirs[1]}" "${target_dirs[2]}" "${target_dirs[3]}" \
         --outputDir "$BUILD_DIR/private/oss-attribution"
     

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_SRC_DIR="$ROOT_DIR/code-editor-src"
+THIRD_PARTY_SRC_DIR="$ROOT_DIR/third-party-src"
+BUILD_DIR="$ROOT_DIR/build"
+
+generate_oss_attribution() {
+    local oss_attribution_dir="$BUILD_DIR/private/oss-attribution"
+    local combined_oss_attribution_output_dir="${1:-$ROOT_DIR/overrides}"
+    local code_oss_version=$(jq -r ".version" "$THIRD_PARTY_SRC_DIR/package.json")
+    local code_oss_license=$(cat "$THIRD_PARTY_SRC_DIR/LICENSE.txt")
+    local code_oss_third_party_licenses=$(cat "$THIRD_PARTY_SRC_DIR/ThirdPartyNotices.txt")
+    additional_third_party_licenses=$(cat "$ROOT_DIR/build-tools/oss-attribution/additional-third-party-licenses.txt")
+
+    npx --yes --package oss-attribution-generator@1.7.1 -- generate-attribution --baseDir "$BUILD_SRC_DIR" --outputDir "$oss_attribution_dir"
+    attribution_licenses=$(cat "$oss_attribution_dir/attribution.txt")
+
+    read_status=0
+    read -r -d '' license_content << EOF || read_status=$?
+$code_oss_third_party_licenses
+
+---------------------------------------------------------
+
+code-oss-dev $code_oss_version
+https://github.com/microsoft/vscode
+
+$code_oss_license
+
+---------------------------------------------------------
+
+$additional_third_party_licenses
+
+---------------------------------------------------------
+$attribution_licenses
+EOF
+    if [[ $read_status -eq 1 ]]; then
+        echo "$license_content" > "$combined_oss_attribution_output_dir/LICENSE-THIRD-PARTY"
+    else
+        echo "Failed to generate OSS attribution"
+        exit 1
+    fi
+}
+
+generate_unified_oss_attribution() {
+    local combined_oss_attribution_output_dir="${1:-$ROOT_DIR/overrides}"
+    local targets=("code-editor-server" "code-editor-sagemaker-server" "code-editor-web-embedded" "code-editor-web-embedded-with-terminal")
+    local target_dirs=()
+    
+    # Prepare source for each target in separate directories
+    for target in "${targets[@]}"; do
+        echo "Preparing source for $target"
+        
+        # Prepare source for this target
+        "$ROOT_DIR/scripts/prepare-src.sh" "$target"
+        
+        # Move to target-specific directory
+        mv "$ROOT_DIR/code-editor-src" "$ROOT_DIR/code-editor-src-$target"
+        cd "$ROOT_DIR/code-editor-src-$target"
+        npm install
+        cd "$ROOT_DIR"
+        
+        # Check for unapproved licenses
+        echo "Checking for unapproved licenses in $target..."
+        local output
+        output=$(cd "$ROOT_DIR/code-editor-src-$target" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD 2>/dev/null || true)
+        
+        if [ -n "$output" ]; then
+            echo "Unapproved licenses found in $target:"
+            echo "$output"
+            echo "Manual review required for unapproved licenses"
+            exit 1
+        fi
+        
+        target_dirs+=("$ROOT_DIR/code-editor-src-$target")
+    done
+    
+    # Generate unified OSS attribution using multiple base directories
+    echo "Generating unified OSS attribution for all targets"
+    mkdir -p "$BUILD_DIR/private/oss-attribution"
+    
+    npx --yes --package oss-attribution-generator@1.7.1 -- generate-attribution \
+        -b "${target_dirs[0]}" "${target_dirs[1]}" "${target_dirs[2]}" "${target_dirs[3]}" \
+        --outputDir "$BUILD_DIR/private/oss-attribution"
+    
+    # Create final LICENSE-THIRD-PARTY with unified attribution
+    local code_oss_version=$(jq -r ".version" "$THIRD_PARTY_SRC_DIR/package.json")
+    local code_oss_license=$(cat "$THIRD_PARTY_SRC_DIR/LICENSE.txt")
+    local code_oss_third_party_licenses=$(cat "$THIRD_PARTY_SRC_DIR/ThirdPartyNotices.txt")
+    local additional_third_party_licenses=$(cat "$ROOT_DIR/build-tools/oss-attribution/additional-third-party-licenses.txt")
+    local attribution_licenses=$(cat "$BUILD_DIR/private/oss-attribution/attribution.txt")
+    
+    cat > "$combined_oss_attribution_output_dir/LICENSE-THIRD-PARTY" << EOF
+$code_oss_third_party_licenses
+
+---------------------------------------------------------
+
+code-oss-dev $code_oss_version
+https://github.com/microsoft/vscode
+
+$code_oss_license
+
+---------------------------------------------------------
+
+$additional_third_party_licenses
+
+---------------------------------------------------------
+$attribution_licenses
+EOF
+    
+    # Clean up target directories
+    rm -rf "$ROOT_DIR/code-editor-src-"*
+}
+
+# Parse command line arguments
+COMMAND="generate_oss_attribution"
+OUTPUT_DIR="$ROOT_DIR/overrides"
+
+case "${1:-}" in
+    --command)
+        [[ $# -ge 2 ]] || { echo "--command requires a value" >&2; exit 1; }
+        COMMAND="$2"
+        OUTPUT_DIR="${3:-$OUTPUT_DIR}"
+        ;;
+    --*)
+        echo "Unknown option $1" >&2
+        exit 1
+        ;;
+    "")
+        # No arguments, use defaults
+        ;;
+    *)
+        OUTPUT_DIR="$1"
+        ;;
+esac
+
+case "$COMMAND" in
+    generate_oss_attribution)
+        generate_oss_attribution "$OUTPUT_DIR"
+        ;;
+    generate_unified_oss_attribution)
+        generate_unified_oss_attribution "$OUTPUT_DIR"
+        ;;
+    *)
+        echo "Unknown command: $COMMAND" >&2
+        echo "Available commands: generate_oss_attribution, generate_unified_oss_attribution" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -15,7 +15,7 @@ generate_oss_attribution() {
     local code_oss_third_party_licenses=$(cat "$THIRD_PARTY_SRC_DIR/ThirdPartyNotices.txt")
     additional_third_party_licenses=$(cat "$ROOT_DIR/build-tools/oss-attribution/additional-third-party-licenses.txt")
 
-    npx --yes --package oss-attribution-generator@1.7.1 -- generate-attribution --baseDir "$BUILD_SRC_DIR" --outputDir "$oss_attribution_dir"
+    npx --yes --package @electrovir/oss-attribution-generator -- generate-attribution --baseDir "$BUILD_SRC_DIR" --outputDir "$oss_attribution_dir"
     attribution_licenses=$(cat "$oss_attribution_dir/attribution.txt")
 
     read_status=0
@@ -67,11 +67,14 @@ generate_unified_oss_attribution() {
         local excluded_packages=""
         if [[ -f "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" ]]; then
             excluded_packages=$(tr '\n' ';' < "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" | sed 's/;$//')
+            echo "Found excluded packages file with packages: $excluded_packages"
+        else
+            echo "No excluded packages file found at: $ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt"
         fi
         
         local output
         if [[ -n "$excluded_packages" ]]; then
-            output=$(cd "$ROOT_DIR/code-editor-src-$target" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages '$excluded_packages' 2>/dev/null || true)
+            output=$(cd "$ROOT_DIR/code-editor-src-$target" && eval "license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages '$excluded_packages'" 2>/dev/null || true)
         else
             output=$(cd "$ROOT_DIR/code-editor-src-$target" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD 2>/dev/null || true)
         fi
@@ -90,7 +93,7 @@ generate_unified_oss_attribution() {
     echo "Generating unified OSS attribution for all targets"
     mkdir -p "$BUILD_DIR/private/oss-attribution"
     
-    npx --yes --package oss-attribution-generator@1.7.1 -- generate-attribution \
+    npx --yes --package @electrovir/oss-attribution-generator -- generate-attribution \
         -b "${target_dirs[0]}" "${target_dirs[1]}" "${target_dirs[2]}" "${target_dirs[3]}" \
         --outputDir "$BUILD_DIR/private/oss-attribution"
     

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -65,8 +65,8 @@ generate_unified_oss_attribution() {
         # Check for unapproved licenses
         echo "Checking for unapproved licenses in $target..."
         local excluded_packages=""
-        if [[ -f "$ROOT_DIR/build-tools/private/oss-attribution/excluded-packages.txt" ]]; then
-            excluded_packages=$(tr '\n' ',' < "$ROOT_DIR/build-tools/private/oss-attribution/excluded-packages.txt" | sed 's/,$//')
+        if [[ -f "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" ]]; then
+            excluded_packages=$(tr '\n' ',' < "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" | sed 's/,$//')
         fi
         
         local output

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -190,8 +190,8 @@ while [[ $# -gt 0 ]]; do
             exit 1
             ;;
         *)
-            OUTPUT_DIR="$1"
-            shift
+            echo "Error: Unexpected argument '$1'" >&2
+            exit 1
             ;;
     esac
 done

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -95,6 +95,7 @@ generate_unified_oss_attribution() {
         # Move to target-specific directory
         mv "$ROOT_DIR/code-editor-src" "$ROOT_DIR/code-editor-src-$target"
         cd "$ROOT_DIR/code-editor-src-$target"
+        npm config set cache "$ROOT_DIR/.npm-cache" --global
         npm install
         cd "$ROOT_DIR"
         

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -86,7 +86,7 @@ generate_oss_attribution() {
     if [ -n "$target" ]; then
         "$ROOT_DIR/scripts/prepare-src.sh" "$target"
         cd "$BUILD_SRC_DIR"
-        npm install
+        npm ci
         cd "$ROOT_DIR"
         
         check_unapproved_licenses "$target" "$BUILD_SRC_DIR"
@@ -134,7 +134,7 @@ generate_unified_oss_attribution() {
             "$ROOT_DIR/scripts/prepare-src.sh" "$target"
             mv "$ROOT_DIR/code-editor-src" "$ROOT_DIR/code-editor-src-$target"
             cd "$ROOT_DIR/code-editor-src-$target"
-            npm install
+            npm ci
             cd "$ROOT_DIR"
             
             target_dirs+=("$ROOT_DIR/code-editor-src-$target")

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -66,12 +66,12 @@ generate_unified_oss_attribution() {
         echo "Checking for unapproved licenses in $target..."
         local excluded_packages=""
         if [[ -f "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" ]]; then
-            excluded_packages=$(tr '\n' ',' < "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" | sed 's/,$//')
+            excluded_packages=$(tr '\n' ';' < "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" | sed 's/;$//')
         fi
         
         local output
         if [[ -n "$excluded_packages" ]]; then
-            output=$(cd "$ROOT_DIR/code-editor-src-$target" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages "$excluded_packages" 2>/dev/null || true)
+            output=$(cd "$ROOT_DIR/code-editor-src-$target" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages '$excluded_packages' 2>/dev/null || true)
         else
             output=$(cd "$ROOT_DIR/code-editor-src-$target" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD 2>/dev/null || true)
         fi

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -7,13 +7,49 @@ BUILD_SRC_DIR="$ROOT_DIR/code-editor-src"
 THIRD_PARTY_SRC_DIR="$ROOT_DIR/third-party-src"
 BUILD_DIR="$ROOT_DIR/build"
 
+check_unapproved_licenses() {
+    local target="$1"
+    local src_dir="$2"
+    
+    echo "Checking for unapproved licenses in $target..."
+    local excluded_packages=""
+    if [[ -f "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" ]]; then
+        excluded_packages=$(tr '\n' ';' < "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" | sed 's/;$//')
+    fi
+    
+    local output
+    if [[ -n "$excluded_packages" ]]; then
+        output=$(cd "$src_dir" && eval "license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages '$excluded_packages'" 2>/dev/null || true)
+    else
+        output=$(cd "$src_dir" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD 2>/dev/null || true)
+    fi
+    
+    if [ -n "$output" ]; then
+        echo "Unapproved licenses found in $target:"
+        echo "$output"
+        echo "Manual review required for unapproved licenses"
+        exit 1
+    fi
+}
+
 generate_oss_attribution() {
-    local oss_attribution_dir="$BUILD_DIR/private/oss-attribution"
     local combined_oss_attribution_output_dir="${1:-$ROOT_DIR/overrides}"
+    local target="$2"
+    local oss_attribution_dir="$BUILD_DIR/private/oss-attribution"
     local code_oss_version=$(jq -r ".version" "$THIRD_PARTY_SRC_DIR/package.json")
     local code_oss_license=$(cat "$THIRD_PARTY_SRC_DIR/LICENSE.txt")
     local code_oss_third_party_licenses=$(cat "$THIRD_PARTY_SRC_DIR/ThirdPartyNotices.txt")
     additional_third_party_licenses=$(cat "$ROOT_DIR/build-tools/oss-attribution/additional-third-party-licenses.txt")
+
+    # Prepare source for target if specified
+    if [ -n "$target" ]; then
+        "$ROOT_DIR/scripts/prepare-src.sh" "$target"
+        cd "$BUILD_SRC_DIR"
+        npm install
+        cd "$ROOT_DIR"
+        
+        check_unapproved_licenses "$target" "$BUILD_SRC_DIR"
+    fi
 
     npx --yes --package @electrovir/oss-attribution-generator -- generate-attribution --baseDir "$BUILD_SRC_DIR" --outputDir "$oss_attribution_dir"
     attribution_licenses=$(cat "$oss_attribution_dir/attribution.txt")
@@ -62,29 +98,7 @@ generate_unified_oss_attribution() {
         npm install
         cd "$ROOT_DIR"
         
-        # Check for unapproved licenses
-        echo "Checking for unapproved licenses in $target..."
-        local excluded_packages=""
-        if [[ -f "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" ]]; then
-            excluded_packages=$(tr '\n' ';' < "$ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt" | sed 's/;$//')
-            echo "Found excluded packages file with packages: $excluded_packages"
-        else
-            echo "No excluded packages file found at: $ROOT_DIR/build-tools/oss-attribution/excluded-packages.txt"
-        fi
-        
-        local output
-        if [[ -n "$excluded_packages" ]]; then
-            output=$(cd "$ROOT_DIR/code-editor-src-$target" && eval "license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages '$excluded_packages'" 2>/dev/null || true)
-        else
-            output=$(cd "$ROOT_DIR/code-editor-src-$target" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD 2>/dev/null || true)
-        fi
-        
-        if [ -n "$output" ]; then
-            echo "Unapproved licenses found in $target:"
-            echo "$output"
-            echo "Manual review required for unapproved licenses"
-            exit 1
-        fi
+        check_unapproved_licenses "$target" "$ROOT_DIR/code-editor-src-$target"
         
         target_dirs+=("$ROOT_DIR/code-editor-src-$target")
     done
@@ -150,7 +164,8 @@ esac
 
 case "$COMMAND" in
     generate_oss_attribution)
-        generate_oss_attribution "$OUTPUT_DIR"
+        TARGET="${4:-code-editor-server}"
+        generate_oss_attribution "$OUTPUT_DIR" "$TARGET"
         ;;
     generate_unified_oss_attribution)
         generate_unified_oss_attribution "$OUTPUT_DIR"

--- a/scripts/generate-oss-attribution.sh
+++ b/scripts/generate-oss-attribution.sh
@@ -64,8 +64,17 @@ generate_unified_oss_attribution() {
         
         # Check for unapproved licenses
         echo "Checking for unapproved licenses in $target..."
+        local excluded_packages=""
+        if [[ -f "$ROOT_DIR/build-tools/private/oss-attribution/excluded-packages.txt" ]]; then
+            excluded_packages=$(tr '\n' ',' < "$ROOT_DIR/build-tools/private/oss-attribution/excluded-packages.txt" | sed 's/,$//')
+        fi
+        
         local output
-        output=$(cd "$ROOT_DIR/code-editor-src-$target" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD 2>/dev/null || true)
+        if [[ -n "$excluded_packages" ]]; then
+            output=$(cd "$ROOT_DIR/code-editor-src-$target" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD --excludePackages "$excluded_packages" 2>/dev/null || true)
+        else
+            output=$(cd "$ROOT_DIR/code-editor-src-$target" && license-checker --production --exclude MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD 2>/dev/null || true)
+        fi
         
         if [ -n "$output" ]; then
             echo "Unapproved licenses found in $target:"


### PR DESCRIPTION
*Description of changes:*
- Added step for generating a unified oss attribution for all targets.
- Added script for generating the oss attribution (`scripts/generate-oss-attribution.sh`).
- Added license checking. Checks for any dependencies that don't have pre-approved licenses.
- Added a `.json` file, `build-tools/oss-attribution/excluded-packages.json`, that contains the packages that were approved and together with their license at the time of approval (The license names should be written in SPDX format). There is a check for them for license changes.
- Added the additional third party licenses in `build-tools/oss-attribution/additional-third-party-licenses.txt`.
- To save time and have a consistent oss attribution, the `generate-oss-attribution` job downloads the prepared sources together with their dependencies installed for all targets that were uploaded by the `update-package-locks` job. They have a 1 day retention and are intended to be used only by subsequent jobs in same workflow run.
- Made fixes according to Mark's comments from https://github.com/aws/code-editor/pull/38.

*Testing:*
Tested on my fork: https://github.com/vpaiu/code-editor/actions/runs/17202360519

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
