### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @aws/aws-code-editor
+/.github/ @aws/aws-code-editor
+/patches/sagemaker.series @aws/aws-code-editor @aws/sagemaker-code-editor
+/patches/sagemaker/ @aws/aws-code-editor @aws/sagemaker-code-editor


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added code owners file.
This grants the AWS Code Editor team default ownership of all files, including the `.github` directory, except the SageMaker related patches (`/patches/sagemaker.series`, `/patches/sagemaker/`) which is co-owned by the AWS Code Editor and SageMaker Code Editor teams

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
