### PR TITLE
Adding publish metrics on execution failure to the update-automation workflow

### DIFF
--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -408,9 +408,26 @@ jobs:
     name: Handle Failures
     runs-on: ubuntu-latest
     needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr]
+    environment: update-automation-workflow-env
     if: failure()
+    permissions:
+      id-token: write # Required for OIDC
+    env:
+      REPOSITORY: ${{ github.repository }}
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
     steps:
-      - name: Report rebase failures
+      - name: Use role credentials for metrics
+        id: aws-creds
+        continue-on-error: ${{ env.REPOSITORY != 'aws/code-editor' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+      - name: Report failure
+        if: steps.aws-creds.outcome == 'success'
         run: |
-          # TODO: Implement metric reporting to CW.
-          exit 1
+          aws cloudwatch put-metric-data \
+            --namespace "GitHub/Workflows" \
+            --metric-name "ExecutionsFailed" \
+            --dimensions "Repository=${{ env.REPOSITORY }},Workflow=UpdateAutomation" \
+            --value 1


### PR DESCRIPTION
*Description of changes:*
- Added metric publishing logic to the `handle-failures` job of the `update-automation` workflow. It publishes metric to the a role dedicated to the workflow each time the execution fails.

*Testing:*
Published metric on my fork by creating similar role for testing: https://github.com/vpaiu/code-editor/actions/runs/17379299607

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
