### PR TITLE
Adding comprehensive metrics update in update automation workflow

### DIFF
--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -431,12 +431,12 @@ jobs:
             --dimensions "Repository=${{ env.REPOSITORY }},Workflow=UpdateAutomation" \
             --value 1
 
-  handle-failures:
-    name: Handle Failures
+  publish-execution-metrics:
+    name: Publish Execution Metrics
     runs-on: ubuntu-latest
     needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification]
     environment: update-automation-workflow-env
-    if: failure()
+    if: always()
     permissions:
       id-token: write # Required for OIDC
     env:
@@ -450,11 +450,19 @@ jobs:
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
-      - name: Report failure
+      - name: Publish execution metrics
         if: steps.aws-creds.outcome == 'success'
         run: |
+          if [ "${{ needs.update-automation.result }}" = "failure" ] || [ "${{ needs.build-and-update-package-locks.result }}" = "failure" ] || [ "${{ needs.generate-oss-attribution.result }}" = "failure" ] || [ "${{ needs.create-pr.result }}" = "failure" ] || [ "${{ needs.send-notification.result }}" = "failure" ]; then
+            METRIC_NAME="ExecutionsFailed"
+          else
+            METRIC_NAME="ExecutionsSucceeded"
+          fi
+          
           aws cloudwatch put-metric-data \
             --namespace "GitHub/Workflows" \
-            --metric-name "ExecutionsFailed" \
+            --metric-name "$METRIC_NAME" \
             --dimensions "Repository=${{ env.REPOSITORY }},Workflow=UpdateAutomation" \
             --value 1
+          
+          echo "Published metric: $METRIC_NAME"

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -436,7 +436,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification]
     environment: update-automation-workflow-env
-    if: success ()
+    if: success()
     permissions:
       id-token: write # Required for OIDC
     env:
@@ -466,7 +466,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification]
     environment: update-automation-workflow-env
-    if: failure ()
+    if: failure()
     permissions:
       id-token: write # Required for OIDC
     env:

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -431,12 +431,12 @@ jobs:
             --dimensions "Repository=${{ env.REPOSITORY }},Workflow=UpdateAutomation" \
             --value 1
 
-  publish-execution-metrics:
-    name: Publish Execution Metrics
+  publish-success-metrics:
+    name: Publish Success Metrics
     runs-on: ubuntu-latest
     needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification]
     environment: update-automation-workflow-env
-    if: always()
+    if: success ()
     permissions:
       id-token: write # Required for OIDC
     env:
@@ -450,19 +450,43 @@ jobs:
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
-      - name: Publish execution metrics
+      - name: Publish success metrics
         if: steps.aws-creds.outcome == 'success'
         run: |
-          if [ "${{ needs.update-automation.result }}" = "failure" ] || [ "${{ needs.build-and-update-package-locks.result }}" = "failure" ] || [ "${{ needs.generate-oss-attribution.result }}" = "failure" ] || [ "${{ needs.create-pr.result }}" = "failure" ] || [ "${{ needs.send-notification.result }}" = "failure" ]; then
-            METRIC_NAME="ExecutionsFailed"
-          else
-            METRIC_NAME="ExecutionsSucceeded"
-          fi
-          
           aws cloudwatch put-metric-data \
             --namespace "GitHub/Workflows" \
-            --metric-name "$METRIC_NAME" \
+            --metric-name "ExecutionsSucceeded" \
             --dimensions "Repository=${{ env.REPOSITORY }},Workflow=UpdateAutomation" \
             --value 1
           
-          echo "Published metric: $METRIC_NAME"
+          echo "Published metric: ExecutionsSucceeded"
+
+  publish-failure-metrics:
+    name: Publish Failure Metrics
+    runs-on: ubuntu-latest
+    needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification]
+    environment: update-automation-workflow-env
+    if: failure ()
+    permissions:
+      id-token: write # Required for OIDC
+    env:
+      REPOSITORY: ${{ github.repository }}
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+    steps:
+      - name: Use role credentials for metrics
+        id: aws-creds
+        continue-on-error: ${{ env.REPOSITORY != 'aws/code-editor' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+      - name: Publish failure metrics
+        if: steps.aws-creds.outcome == 'success'
+        run: |
+          aws cloudwatch put-metric-data \
+            --namespace "GitHub/Workflows" \
+            --metric-name "ExecutionsFailed" \
+            --dimensions "Repository=${{ env.REPOSITORY }},Workflow=UpdateAutomation" \
+            --value 1
+          
+          echo "Published metric: ExecutionsFailed"


### PR DESCRIPTION
*Issue #, if available:*
taskei: https://taskei.amazon.dev/tasks/D284470005?activeTab=comments
Currently, update automation action only reports metrics when the action fails. However, in order to monitor if scheduled update is in place, there needs to be metrics sent to cloudwatch, no matter if the action successes or fails.

*Description of changes:*
This PR refactored execution metrics reporting to dynamically handle success and failure cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
