### PR TITLE
Fix issues for the Security Scan Workflow

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -5,7 +5,7 @@ env:
 
 on:
   # Trigger 1: PR created on main or version branches (*.*)
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - '*.*'
@@ -257,6 +257,7 @@ jobs:
           # security scan scripts. So we download the latest one from main
           echo "Downloading latest security-scan.sh script from main branch"
           curl -sSL "https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/security-scan.sh" -o scripts/security-scan.sh
+          sudo chmod +x scripts/security-scan.sh
           echo "Updated security-scan.sh to latest version from main"
       
       - name: Set up environment
@@ -461,6 +462,7 @@ jobs:
           # security scan scripts. So we download the latest one from main
           echo "Downloading latest security-scan.sh script from main branch"
           curl -sSL "https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/security-scan.sh" -o scripts/security-scan.sh
+          sudo chmod +x scripts/security-scan.sh
           echo "Updated security-scan.sh to latest version from main"
       
       - name: Install Security Scan Dependencies

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -63,7 +63,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           # Get main branch and all version branches (*.*)
-          branches=$(git branch -r | grep -E 'origin/(main|[0-9]+\.[0-9]+)' | sed 's/origin\///' | tr '\n' ' ')
+          branches=$(git branch -r | grep -E 'origin/(main|[0-9]+\.[0-9]+)$' | sed 's/origin\///' | tr '\n' ' ')
           echo "Found upstream branches: $branches"
           echo "upstream-branches=$branches" >> $GITHUB_OUTPUT
           echo "output-branch-name=scheduled" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description of changes:

This PR fixes the following issues in the Security Scanning workflow.
1. AccessDenied error when assuming IAM role from a PR: GitHub does not allow PRs to access repo secrets if the `pull_request` trigger is used for invoking a GitHub Action. This is because GitHub considers this unsafe as with the `pull_request` trigger, the GitHub Action's `.yaml` file that's used to invoke the workflow is from the PR branch. The trigger has now been updated to `pull_request_target`. With `pull_request_target` as the trigger, the GitHub Action's `.yaml` file will be from the base branch of the PR. This is  more secure as it doesn't allow untrusted code to invoke a workflow and will also grant access to GitHub repo secrets.
2. ./scripts/security-scan.sh: Permission denied error: For each branch scan, the security-scan.sh file is always downloaded from the `main` branch to ensure latest changes in the script are used for running the scan. After downloading, the file needs "execute" permissions. This is fixed by updating file permissions using `sudo chmod +x`.
3. Regex for fetching upstream branches for scanning: The previous regex also considered `1.95.x` branch for security scanning. The regex has been fixed, it will now consider `main` and `<digit>.<digit>` branches and will no longer consider `*.*.x` branches as eligible for scanning. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
