### PR TITLE
Fix security scanning for fork-origin PR

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -235,7 +235,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
-          role-session-name: security-scan-${{ matrix.target }}-${{matrix.branch}}
+          role-session-name: scan-${{ matrix.target }}-${{matrix.branch}}
       
       - name: Publish Scan Invoked metric
         run: |
@@ -248,7 +248,9 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.branch }}
+          # For fork-origin PRs, we can't directly use matrix.branch as the branch does not exist in the 
+          # Code Editor repo. The branch only exists in the fork.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || matrix.branch }}
           submodules: recursive
 
       - name: Update security scan script from main
@@ -440,7 +442,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
-          role-session-name: security-scan-global-dependencies-${{matrix.branch}}
+          role-session-name: scan-global-dependencies-${{matrix.branch}}
       
       - name: Publish Scan Invoked metric
         run: |
@@ -453,7 +455,9 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.branch }}
+          # For fork-origin PRs, we can't directly use matrix.branch as the branch does not exist in the 
+          # Code Editor repo. The branch only exists in the fork.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || matrix.branch }}
           submodules: recursive
 
       - name: Update security scan script from main


### PR DESCRIPTION
## Description of changes:

This PR addresses an issue for the security scanning workflow when new PRs are created from forks. The security scan workflow must check out out code from the PR branch and then run scans on it. However, for a fork-origin PR, the PR branch does not exist in the `aws/code-editor` repo, it only exists in the fork repo. 

The scan workflow used to error out before as it was unable to find the PR branch. The current PR fixes that by relying on `github.event.pull_request.head.sha` when the workflow is invoked for a `pull_request_target` event.  

Besides that, this PR also removes the prefix `security-` from `role-session-name` when assuming the AWS IAM role. This is because the `role-session-name` has a 64 character limit and a few PRs have failed on this step because the character limit was breached. 

## Testing

Tested out for fork-origin PR and for branch-origin PR in a fork:
1. Successful run for branch-origin PR: https://github.com/sachinh-amazon/code-editor/actions/runs/18190140321
2. Successful run for fork-origin PR: https://github.com/sachinh-amazon/code-editor/actions/runs/18189779024

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
