### PR TITLE
Adding metric of time since last CodeOSS version update in update automation workflow

### DIFF
--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -404,6 +404,36 @@ jobs:
             
           echo "Created PR from ${{ needs.update-automation.outputs.staging-branch }} to $TARGET_BRANCH"
 
+  publish-new-release-detected:
+    name: Publish New Release Detected Metric
+    runs-on: ubuntu-latest
+    needs: [update-automation]
+    if: needs.update-automation.outputs.staging-branch != ''
+    environment: update-automation-workflow-env
+    permissions:
+      id-token: write # Required for OIDC
+    env:
+      REPOSITORY: ${{ github.repository }}
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+    steps:
+      - name: Use role credentials for metrics
+        id: aws-creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+      - name: Publish new release detected metric
+        if: steps.aws-creds.outcome == 'success'
+        run: |
+          aws cloudwatch put-metric-data \
+            --namespace "GitHub/Workflows" \
+            --metric-name "NewReleaseDetected" \
+            --dimensions "Repository=${{ env.REPOSITORY }},Workflow=UpdateAutomation" \
+            --value 1 \
+            --timestamp $(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+          
+          echo "Published metric: NewReleaseDetected for version ${{ needs.update-automation.outputs.latest-code-oss-tag }}"
+
   send-notification:
     name: Send Notification
     runs-on: ubuntu-latest
@@ -434,7 +464,7 @@ jobs:
   publish-success-metrics:
     name: Publish Success Metrics
     runs-on: ubuntu-latest
-    needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification]
+    needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification, publish-new-release-detected]
     environment: update-automation-workflow-env
     if: always() && !failure() && !cancelled()
     permissions:
@@ -463,7 +493,7 @@ jobs:
   publish-failure-metrics:
     name: Publish Failure Metrics
     runs-on: ubuntu-latest
-    needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification]
+    needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification, publish-new-release-detected]
     environment: update-automation-workflow-env
     if: failure()
     permissions:

--- a/.github/workflows/update-automation.yaml
+++ b/.github/workflows/update-automation.yaml
@@ -404,35 +404,52 @@ jobs:
             
           echo "Created PR from ${{ needs.update-automation.outputs.staging-branch }} to $TARGET_BRANCH"
 
-  publish-new-release-detected:
-    name: Publish New Release Detected Metric
+  publish-release-lag-metric:
+    name: Publish Release Lag Metric
     runs-on: ubuntu-latest
     needs: [update-automation]
-    if: needs.update-automation.outputs.staging-branch != ''
+    if: always()
     environment: update-automation-workflow-env
     permissions:
       id-token: write # Required for OIDC
+      contents: read
     env:
       REPOSITORY: ${{ github.repository }}
       AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 1
+          
       - name: Use role credentials for metrics
         id: aws-creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
-      - name: Publish new release detected metric
+          
+      - name: Calculate and publish release lag metric
         if: steps.aws-creds.outcome == 'success'
         run: |
+          cd third-party-src
+          SUBMODULE_COMMIT_TIMESTAMP=$(git log -1 --format=%ct)
+          cd ..
+          
+          CURRENT_TIMESTAMP=$(date +%s)
+          SECONDS_BEHIND=$((CURRENT_TIMESTAMP - SUBMODULE_COMMIT_TIMESTAMP))
+          NORMALIZED_VALUE=$(awk "BEGIN {printf \"%.6f\", $SECONDS_BEHIND / 2592000}") 
+          
           aws cloudwatch put-metric-data \
             --namespace "GitHub/Workflows" \
-            --metric-name "NewReleaseDetected" \
+            --metric-name "CodeOSSReleaseLag" \
             --dimensions "Repository=${{ env.REPOSITORY }},Workflow=UpdateAutomation" \
-            --value 1 \
-            --timestamp $(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+            --value $NORMALIZED_VALUE \
+            --unit None
           
-          echo "Published metric: NewReleaseDetected for version ${{ needs.update-automation.outputs.latest-code-oss-tag }}"
+          DAYS_BEHIND=$((SECONDS_BEHIND / 86400))
+          echo "Published metric: CodeOSSReleaseLag = $NORMALIZED_VALUE (equivalent to $DAYS_BEHIND days behind upstream)"
 
   send-notification:
     name: Send Notification
@@ -464,7 +481,7 @@ jobs:
   publish-success-metrics:
     name: Publish Success Metrics
     runs-on: ubuntu-latest
-    needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification, publish-new-release-detected]
+    needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification, publish-release-lag-metric]
     environment: update-automation-workflow-env
     if: always() && !failure() && !cancelled()
     permissions:
@@ -493,7 +510,7 @@ jobs:
   publish-failure-metrics:
     name: Publish Failure Metrics
     runs-on: ubuntu-latest
-    needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification, publish-new-release-detected]
+    needs: [update-automation, build-and-update-package-locks, generate-oss-attribution, create-pr, send-notification, publish-release-lag-metric]
     environment: update-automation-workflow-env
     if: failure()
     permissions:


### PR DESCRIPTION
*Issue #, if available:*
Because Automation Update workflow makes assumptions on CodeOSS version update, it's possible that CodeEditor version is behind CodeOSS for longer than 1 month while Github Action still publishes success metric to CloudWatch during execution, which leads to undetected update problem.

*Description of changes:*
New metric CodeOSSReleaseLag is published to calculate second elapsed since last update, monitored by timestamp of last commit in third-party-src in repository. The value is normalized to month (so 1.0 means 1 month)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
