### PR TITLE
Sync changes from 1.1 into main branch

### DIFF
--- a/patches/common/installer.diff
+++ b/patches/common/installer.diff
@@ -28,7 +28,7 @@ Index: third-party-src/build/gulpfile.reh.ts
 +	if (process.env['CUSTOM_NODE_PATH']) {
 +		log(`Bundling custom Node from '${process.env['CUSTOM_NODE_PATH']}'...`);
 +		return gulp.src(process.env['CUSTOM_NODE_PATH'])
-+			.pipe(flatmap(stream => stream.pipe(gunzip()).pipe(untar())))
++			.pipe(flatmap(stream => stream.pipe(gunzip()).pipe(util.untar())))
 +			.pipe(filter('**/node'))
 +			.pipe(util.setExecutableBit('**'))
 +			.pipe(rename('node'));

--- a/patches/common/preapplied/remove-unsafe-headers.diff
+++ b/patches/common/preapplied/remove-unsafe-headers.diff
@@ -24,19 +24,6 @@ Index: third-party-src/src/vs/workbench/contrib/notebook/browser/view/renderers/
  					style-src ${webviewGenericCspSource} 'unsafe-inline';
  					img-src ${webviewGenericCspSource} https: http: data:;
  					font-src ${webviewGenericCspSource} https:;
-Index: third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
-===================================================================
---- third-party-src.orig/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
-+++ third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
-@@ -4,7 +4,7 @@
- 		<meta http-equiv="Content-Security-Policy" content="
- 			default-src 'none';
- 			child-src 'self' data: blob:;
--			script-src 'self' 'unsafe-eval' 'sha256-cl8ijlOzEe+0GRCQNJQu2k6nUQ0fAYNYIuuKEm72JDs=' https: http://localhost:* blob:;
-+			script-src 'self' 'wasm-unsafe-eval' 'sha256-cl8ijlOzEe+0GRCQNJQu2k6nUQ0fAYNYIuuKEm72JDs=' https: http://localhost:* blob:;
- 			connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*;"/>
- 	</head>
- 	<body>
 Index: third-party-src/src/vs/code/electron-browser/workbench/workbench-dev.html
 ===================================================================
 --- third-party-src.orig/src/vs/code/electron-browser/workbench/workbench-dev.html

--- a/patches/internal/build.diff
+++ b/patches/internal/build.diff
@@ -1,91 +1,10 @@
 Patch that is needed for producing internal builds.
 
-Index: third-party-src/build/lib/mangle/index.ts
-===================================================================
---- third-party-src.orig/build/lib/mangle/index.ts
-+++ third-party-src/build/lib/mangle/index.ts
-@@ -407,7 +407,7 @@ export class Mangler {
- 	) {
- 
- 		this.renameWorkerPool = workerpool.pool(path.join(__dirname, 'renameWorker.js'), {
--			maxWorkers: 4,
-+			maxWorkers: 3,
- 			minWorkers: 'max'
- 		});
- 	}
-Index: third-party-src/build/lib/mangle/index.js
-===================================================================
---- third-party-src.orig/build/lib/mangle/index.js
-+++ third-party-src/build/lib/mangle/index.js
-@@ -354,7 +354,7 @@ class Mangler {
-         this.log = log;
-         this.config = config;
-         this.renameWorkerPool = workerpool_1.default.pool(path_1.default.join(__dirname, 'renameWorker.js'), {
--            maxWorkers: 4,
-+            maxWorkers: 3,
-             minWorkers: 'max'
-         });
-     }
-Index: third-party-src/build/lib/extensions.js
-===================================================================
---- third-party-src.orig/build/lib/extensions.js
-+++ third-party-src/build/lib/extensions.js
-@@ -125,6 +125,21 @@ function fromLocal(extensionPath, forWeb
-     }
-     return input;
- }
-+async function asyncRetry(func, maxRetries) {
-+	let retryNum = 0;
-+	for(;;) {
-+		try {
-+			return await func();
-+		} catch(err) {
-+			retryNum++;
-+			if (retryNum == maxRetries) {
-+				throw err;
-+			} else {
-+				console.warn(`retrying operation, attempt ${retryNum} out of ${maxRetries}`);
-+			}
-+		}
-+	}
-+}
- function fromLocalWebpack(extensionPath, webpackConfigFileName, disableMangle) {
-     const vsce = require('@vscode/vsce');
-     const webpack = require('webpack');
-@@ -140,12 +155,15 @@ function fromLocalWebpack(extensionPath,
-             }
-         }
-     }
-+    // During building, some of the parallel `npm list --prod --json` calls were failing intermittently
-+    // A failure causes the whole build process to fail, but the operation seems to succeed on retry
-+    // Added this retry to make the build process more stable
-     // TODO: add prune support based on packagedDependencies to vsce.PackageManager.Npm similar
-     // to vsce.PackageManager.Yarn.
-     // A static analysis showed there are no webpack externals that are dependencies of the current
-     // local extensions so we can use the vsce.PackageManager.None config to ignore dependencies list
-     // as a temporary workaround.
--    vsce.listFiles({ cwd: extensionPath, packageManager: vsce.PackageManager.None, packagedDependencies }).then(fileNames => {
-+    asyncRetry(() => vsce.listFiles({ cwd: extensionPath, packageManager: vsce.PackageManager.None, packagedDependencies }), 3).then(fileNames => {
-         const files = fileNames
-             .map(fileName => path_1.default.join(extensionPath, fileName))
-             .map(filePath => new vinyl_1.default({
-@@ -228,7 +246,10 @@ function fromLocalWebpack(extensionPath,
- function fromLocalNormal(extensionPath) {
-     const vsce = require('@vscode/vsce');
-     const result = event_stream_1.default.through();
--    vsce.listFiles({ cwd: extensionPath, packageManager: vsce.PackageManager.Npm })
-+    // During building, some of the parallel `npm list --prod --json` calls were failing intermittently
-+    // A failure causes the whole build process to fail, but the operation seems to succeed on retry
-+    // Added this retry to make the build process more stable
-+    asyncRetry(() => vsce.listFiles({ cwd: extensionPath, packageManager: vsce.PackageManager.Npm }), 3)
-         .then(fileNames => {
-         const files = fileNames
-             .map(fileName => path_1.default.join(extensionPath, fileName))
 Index: third-party-src/build/lib/extensions.ts
 ===================================================================
 --- third-party-src.orig/build/lib/extensions.ts
 +++ third-party-src/build/lib/extensions.ts
-@@ -89,6 +89,21 @@ function fromLocal(extensionPath: string
+@@ -90,6 +90,21 @@ function fromLocal(extensionPath: string
  	return input;
  }
  
@@ -107,11 +26,10 @@ Index: third-party-src/build/lib/extensions.ts
  
  function fromLocalWebpack(extensionPath: string, webpackConfigFileName: string, disableMangle: boolean): Stream {
  	const vsce = require('@vscode/vsce') as typeof import('@vscode/vsce');
-@@ -106,13 +121,15 @@ function fromLocalWebpack(extensionPath:
- 			}
+@@ -108,12 +123,15 @@ function fromLocalWebpack(extensionPath:
  		}
  	}
--
+ 
 +	// During building, some of the parallel `npm list --prod --json` calls were failing intermittently
 +	// A failure causes the whole build process to fail, but the operation seems to succeed on retry
 +	// Added this retry to make the build process more stable
@@ -125,7 +43,7 @@ Index: third-party-src/build/lib/extensions.ts
  		const files = fileNames
  			.map(fileName => path.join(extensionPath, fileName))
  			.map(filePath => new File({
-@@ -208,8 +225,10 @@ function fromLocalWebpack(extensionPath:
+@@ -208,8 +226,10 @@ function fromLocalWebpack(extensionPath:
  function fromLocalNormal(extensionPath: string): Stream {
  	const vsce = require('@vscode/vsce') as typeof import('@vscode/vsce');
  	const result = es.through();
@@ -138,64 +56,86 @@ Index: third-party-src/build/lib/extensions.ts
  		.then(fileNames => {
  			const files = fileNames
  				.map(fileName => path.join(extensionPath, fileName))
-Index: third-party-src/package.json
-===================================================================
---- third-party-src.orig/package.json
-+++ third-party-src/package.json
-@@ -32,7 +32,7 @@
-     "watch-extensionsd": "deemon npm run watch-extensions",
-     "kill-watch-extensionsd": "deemon --kill npm run watch-extensions",
-     "precommit": "node build/hygiene.js",
--    "gulp": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js",
-+    "gulp": "NODE_OPTIONS=\"${NODE_OPTIONS:---max-old-space-size=8192}\" node ./node_modules/gulp/bin/gulp.js",
-     "electron": "node build/lib/electron",
-     "7z": "7z",
-     "update-grammars": "node build/npm/update-all-grammars.mjs",
-@@ -77,7 +77,6 @@
-     "@vscode/iconv-lite-umd": "0.7.0",
-     "@vscode/policy-watcher": "^1.3.2",
-     "@vscode/proxy-agent": "^0.37.0",
--    "@vscode/ripgrep": "^1.15.11",
-     "@vscode/spdlog": "^0.15.2",
-     "@vscode/sqlite3": "5.1.12-vscode",
-     "@vscode/sudo-prompt": "9.3.1",
-@@ -102,7 +101,6 @@
-     "jschardet": "3.1.4",
-     "minimist": "^1.2.6",
-     "native-is-elevated": "0.7.0",
--    "native-keymap": "^3.3.5",
-     "native-watchdog": "^1.4.1",
-     "node-pty": "^1.1.0-beta33",
-     "open": "^8.4.2",
-@@ -140,7 +137,6 @@
-     "@typescript-eslint/utils": "^8.8.0",
-     "@vscode/gulp-electron": "^1.36.0",
-     "@vscode/l10n-dev": "0.0.35",
--    "@vscode/telemetry-extractor": "^1.10.2",
-     "@vscode/test-cli": "^0.0.6",
-     "@vscode/test-electron": "^2.4.0",
-     "@vscode/test-web": "^0.0.62",
-Index: third-party-src/remote/package.json
-===================================================================
---- third-party-src.orig/remote/package.json
-+++ third-party-src/remote/package.json
-@@ -9,7 +9,6 @@
-     "@vscode/deviceid": "^0.1.1",
-     "@vscode/iconv-lite-umd": "0.7.0",
-     "@vscode/proxy-agent": "^0.37.0",
--    "@vscode/ripgrep": "^1.15.11",
-     "@vscode/spdlog": "^0.15.2",
-     "@vscode/tree-sitter-wasm": "^0.1.4",
-     "@vscode/vscode-languagedetection": "1.0.21",
 Index: third-party-src/build/package.json
 ===================================================================
 --- third-party-src.orig/build/package.json
 +++ third-party-src/build/package.json
-@@ -36,7 +36,6 @@
+@@ -42,8 +42,8 @@
      "@types/workerpool": "^6.4.0",
      "@types/xml2js": "0.0.33",
-     "@vscode/iconv-lite-umd": "0.7.0",
--    "@vscode/ripgrep": "^1.15.10",
-     "@vscode/vsce": "2.20.1",
+     "@vscode/iconv-lite-umd": "0.7.1",
+-    "@vscode/ripgrep": "^1.15.13",
+     "@vscode/vsce": "3.6.1",
++    "@vscode/vsce-sign": "file:../../../../build-tools/vsce-sign",
+     "ansi-colors": "^3.2.3",
      "byline": "^5.0.0",
-     "cssnano": "^7.0.7",
+     "debug": "^4.3.2",
+Index: third-party-src/remote/package.json
+===================================================================
+--- third-party-src.orig/remote/package.json
++++ third-party-src/remote/package.json
+@@ -8,7 +8,6 @@
+     "@vscode/deviceid": "^0.1.1",
+     "@vscode/iconv-lite-umd": "0.7.1",
+     "@vscode/proxy-agent": "^0.37.0",
+-    "@vscode/ripgrep": "^1.15.13",
+     "@vscode/spdlog": "^0.15.2",
+     "@vscode/tree-sitter-wasm": "^0.3.0",
+     "@vscode/vscode-languagedetection": "1.0.21",
+@@ -39,7 +38,8 @@
+     "vscode-regexpp": "^3.1.0",
+     "vscode-textmate": "^9.3.0",
+     "yauzl": "^3.0.0",
+-    "yazl": "^2.4.3"
++    "yazl": "^2.4.3",
++    "@vscode/vsce-sign": "file:../../../../build-tools/vsce-sign"
+   },
+   "overrides": {
+     "node-gyp-build": "4.8.1"
+Index: third-party-src/package.json
+===================================================================
+--- third-party-src.orig/package.json
++++ third-party-src/package.json
+@@ -34,7 +34,7 @@
+     "watch-extensionsd": "deemon npm run watch-extensions",
+     "kill-watch-extensionsd": "deemon --kill npm run watch-extensions",
+     "precommit": "node build/hygiene.ts",
+-    "gulp": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js",
++    "gulp": "NODE_OPTIONS=\"${NODE_OPTIONS:---max-old-space-size=8192}\" node ./node_modules/gulp/bin/gulp.js",
+     "electron": "node build/lib/electron.ts",
+     "7z": "7z",
+     "update-grammars": "node build/npm/update-all-grammars.ts",
+@@ -79,7 +79,6 @@
+     "@vscode/iconv-lite-umd": "0.7.1",
+     "@vscode/policy-watcher": "^1.3.2",
+     "@vscode/proxy-agent": "^0.37.0",
+-    "@vscode/ripgrep": "^1.15.13",
+     "@vscode/spdlog": "^0.15.2",
+     "@vscode/sqlite3": "5.1.12-vscode",
+     "@vscode/sudo-prompt": "9.3.1",
+@@ -105,7 +104,6 @@
+     "katex": "^0.16.22",
+     "minimist": "^1.2.8",
+     "native-is-elevated": "0.8.0",
+-    "native-keymap": "^3.3.5",
+     "native-watchdog": "^1.4.1",
+     "node-pty": "^1.1.0-beta43",
+     "open": "^10.1.2",
+@@ -144,7 +142,6 @@
+     "@typescript/native-preview": "^7.0.0-dev.20250812.1",
+     "@vscode/gulp-electron": "^1.38.2",
+     "@vscode/l10n-dev": "0.0.35",
+-    "@vscode/telemetry-extractor": "^1.10.2",
+     "@vscode/test-cli": "^0.0.6",
+     "@vscode/test-electron": "^2.4.0",
+     "@vscode/test-web": "^0.0.76",
+@@ -236,7 +233,8 @@
+       "koa": "^3.0.3"
+     },
+     "postcss": "^8.4.31",
+-    "playwright": "^1.55.1"
++    "playwright": "^1.55.1",
++    "@vscode/vsce-sign": "file:../../../build-tools/vsce-sign"
+   },
+   "repository": {
+     "type": "git",

--- a/patches/internal/package-overrides.diff
+++ b/patches/internal/package-overrides.diff
@@ -1,18 +1,5 @@
 Package overrides that is needed for producing internal builds.
 
-Index: third-party-src/package.json
-===================================================================
---- third-party-src.orig/package.json
-+++ third-party-src/package.json
-@@ -102,7 +102,7 @@
-     "minimist": "^1.2.6",
-     "native-is-elevated": "0.7.0",
-     "native-watchdog": "^1.4.1",
--    "node-pty": "^1.1.0-beta33",
-+    "node-pty": "1.1.0-beta33",
-     "open": "^8.4.2",
-     "tas-client-umd": "0.2.0",
-     "v8-inspect-profiler": "^0.1.1",
 Index: third-party-src/extensions/emmet/package.json
 ===================================================================
 --- third-party-src.orig/extensions/emmet/package.json
@@ -34,7 +21,7 @@ Index: third-party-src/extensions/css-language-features/package.json
      ]
    },
    "dependencies": {
--    "vscode-languageclient": "^10.0.0-next.15",
+-    "vscode-languageclient": "^10.0.0-next.18",
 +    "vscode-languageclient": "10.0.0-next.9",
      "vscode-uri": "^3.1.0"
    },
@@ -57,16 +44,16 @@ Index: third-party-src/extensions/html-language-features/package.json
 ===================================================================
 --- third-party-src.orig/extensions/html-language-features/package.json
 +++ third-party-src/extensions/html-language-features/package.json
-@@ -259,7 +259,7 @@
+@@ -265,7 +265,7 @@
    },
    "dependencies": {
      "@vscode/extension-telemetry": "^0.9.8",
--    "vscode-languageclient": "^10.0.0-next.15",
+-    "vscode-languageclient": "^10.0.0-next.18",
 +    "vscode-languageclient": "10.0.0-next.9",
      "vscode-uri": "^3.1.0"
    },
    "devDependencies": {
-@@ -268,5 +268,13 @@
+@@ -274,5 +274,13 @@
    "repository": {
      "type": "git",
      "url": "https://github.com/microsoft/vscode.git"
@@ -84,16 +71,16 @@ Index: third-party-src/extensions/json-language-features/package.json
 ===================================================================
 --- third-party-src.orig/extensions/json-language-features/package.json
 +++ third-party-src/extensions/json-language-features/package.json
-@@ -170,7 +170,7 @@
+@@ -171,7 +171,7 @@
    "dependencies": {
      "@vscode/extension-telemetry": "^0.9.8",
      "request-light": "^0.8.0",
--    "vscode-languageclient": "^10.0.0-next.15"
+-    "vscode-languageclient": "^10.0.0-next.18"
 +    "vscode-languageclient": "10.0.0-next.9"
    },
    "devDependencies": {
      "@types/node": "22.x"
-@@ -178,5 +178,13 @@
+@@ -179,5 +179,13 @@
    "repository": {
      "type": "git",
      "url": "https://github.com/microsoft/vscode.git"
@@ -114,8 +101,8 @@ Index: third-party-src/extensions/css-language-features/server/package.json
 @@ -12,7 +12,7 @@
    "dependencies": {
      "@vscode/l10n": "^0.0.18",
-     "vscode-css-languageservice": "^6.3.6",
--    "vscode-languageserver": "^10.0.0-next.13",
+     "vscode-css-languageservice": "^6.3.9",
+-    "vscode-languageserver": "^10.0.0-next.15",
 +    "vscode-languageserver": "10.0.0-next.7",
      "vscode-uri": "^3.1.0"
    },
@@ -140,9 +127,9 @@ Index: third-party-src/extensions/html-language-features/server/package.json
 +++ third-party-src/extensions/html-language-features/server/package.json
 @@ -12,8 +12,8 @@
      "@vscode/l10n": "^0.0.18",
-     "vscode-css-languageservice": "^6.3.6",
-     "vscode-html-languageservice": "^5.5.0",
--    "vscode-languageserver": "^10.0.0-next.13",
+     "vscode-css-languageservice": "^6.3.9",
+     "vscode-html-languageservice": "^5.6.1",
+-    "vscode-languageserver": "^10.0.0-next.15",
 -    "vscode-languageserver-textdocument": "^1.0.12",
 +    "vscode-languageserver": "10.0.0-next.7",
 +    "vscode-languageserver-textdocument": "1.0.12",
@@ -170,8 +157,8 @@ Index: third-party-src/extensions/json-language-features/server/package.json
 @@ -16,7 +16,7 @@
      "jsonc-parser": "^3.3.1",
      "request-light": "^0.8.0",
-     "vscode-json-languageservice": "^5.6.0",
--    "vscode-languageserver": "^10.0.0-next.13",
+     "vscode-json-languageservice": "^5.6.4",
+-    "vscode-languageserver": "^10.0.0-next.15",
 +    "vscode-languageserver": "10.0.0-next.7",
      "vscode-uri": "^3.1.0"
    },
@@ -194,7 +181,7 @@ Index: third-party-src/extensions/css-language-features/server/package-lock.json
 ===================================================================
 --- third-party-src.orig/extensions/css-language-features/server/package-lock.json
 +++ third-party-src/extensions/css-language-features/server/package-lock.json
-@@ -93,12 +93,6 @@
+@@ -94,12 +94,6 @@
          "vscode-languageserver-types": "3.17.6-next.6"
        }
      },
@@ -211,7 +198,7 @@ Index: third-party-src/extensions/html-language-features/server/package-lock.jso
 ===================================================================
 --- third-party-src.orig/extensions/html-language-features/server/package-lock.json
 +++ third-party-src/extensions/html-language-features/server/package-lock.json
-@@ -107,12 +107,6 @@
+@@ -108,12 +108,6 @@
          "vscode-languageserver-types": "3.17.6-next.6"
        }
      },
@@ -228,7 +215,7 @@ Index: third-party-src/extensions/json-language-features/server/package-lock.jso
 ===================================================================
 --- third-party-src.orig/extensions/json-language-features/server/package-lock.json
 +++ third-party-src/extensions/json-language-features/server/package-lock.json
-@@ -109,12 +109,6 @@
+@@ -110,12 +110,6 @@
          "vscode-languageserver-types": "3.17.6-next.6"
        }
      },
@@ -279,7 +266,7 @@ Index: third-party-src/extensions/html-language-features/server/src/htmlServer.t
  } from './modes/languageModes';
  
  import { format } from './modes/formatting';
-@@ -215,9 +214,6 @@ export function startServer(connection:
+@@ -216,9 +215,6 @@ export function startServer(connection:
  				interFileDependencies: false,
  				workspaceDiagnostics: false
  			},
@@ -289,7 +276,7 @@ Index: third-party-src/extensions/html-language-features/server/src/htmlServer.t
  		};
  		return { capabilities };
  	});
-@@ -588,18 +584,6 @@ export function startServer(connection:
+@@ -590,18 +586,6 @@ export function startServer(connection:
  		});
  	});
  

--- a/patches/web-embedded/remove-unsafe-eval-and-unsafe-inline-from-csp-direct.diff
+++ b/patches/web-embedded/remove-unsafe-eval-and-unsafe-inline-from-csp-direct.diff
@@ -65,7 +65,7 @@ Index: third-party-src/src/vs/workbench/services/extensions/worker/webWorkerExte
  		<meta http-equiv="Content-Security-Policy" content="
  			default-src 'none';
  			child-src 'self' data: blob:;
--			script-src 'self' 'wasm-unsafe-eval' 'sha256-cl8ijlOzEe+0GRCQNJQu2k6nUQ0fAYNYIuuKEm72JDs=' https: http://localhost:* blob:;
+-			script-src 'self' 'unsafe-eval' 'sha256-cl8ijlOzEe+0GRCQNJQu2k6nUQ0fAYNYIuuKEm72JDs=' https: http://localhost:* blob:;
 +			script-src 'self' 'sha256-cl8ijlOzEe+0GRCQNJQu2k6nUQ0fAYNYIuuKEm72JDs=' https: http://localhost:* blob:;
  			connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*;"/>
  	</head>


### PR DESCRIPTION
## Backporting
Cherrypicking changes in 1.1 into main.
Changes involve:
* relaxing security policy to resolve vim extension installation failure on code editor sagemaker
* Syncing patches in gitfarm back to github after patch rebasing conflict is resolved and build is successful on gitfarm.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.