### PR TITLE
Update undici

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -7162,7 +7162,7 @@ PERFORMANCE OF THIS SOFTWARE.
 ******************************
 
 undici
-7.19.0 <https://github.com/nodejs/undici>
+7.24.4 <https://github.com/nodejs/undici>
 MIT License
 
 Copyright (c) Matteo Collina and Undici contributors

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -7162,7 +7162,7 @@ PERFORMANCE OF THIS SOFTWARE.
 ******************************
 
 undici
-7.19.0 <https://github.com/nodejs/undici>
+7.24.4 <https://github.com/nodejs/undici>
 MIT License
 
 Copyright (c) Matteo Collina and Undici contributors

--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -52,7 +52,7 @@
         "open": "^10.1.2",
         "playwright-core": "1.59.0-alpha-2026-02-20",
         "tas-client": "0.3.1",
-        "undici": "^7.18.2",
+        "undici": "^7.24.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -20791,9 +20791,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
-      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/sagemaker.series/remote/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/remote/package-lock.json
@@ -41,7 +41,6 @@
         "minimist": "^1.2.8",
         "node-pty": "^1.2.0-beta.10",
         "tas-client": "0.3.1",
-        "undici": "^7.18.2",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -1088,9 +1087,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -51,7 +51,7 @@
         "open": "^10.1.2",
         "playwright-core": "1.59.0-alpha-2026-02-20",
         "tas-client": "0.3.1",
-        "undici": "^7.18.2",
+        "undici": "^7.24.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -20754,9 +20754,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
-      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
@@ -40,7 +40,6 @@
         "minimist": "^1.2.8",
         "node-pty": "^1.2.0-beta.10",
         "tas-client": "0.3.1",
-        "undici": "^7.18.2",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -1041,9 +1040,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -51,7 +51,7 @@
         "open": "^10.1.2",
         "playwright-core": "1.59.0-alpha-2026-02-20",
         "tas-client": "0.3.1",
-        "undici": "^7.18.2",
+        "undici": "^7.24.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -20754,9 +20754,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
-      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/remote/package-lock.json
@@ -40,7 +40,6 @@
         "minimist": "^1.2.8",
         "node-pty": "^1.2.0-beta.10",
         "tas-client": "0.3.1",
-        "undici": "^7.18.2",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -1041,9 +1040,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -52,7 +52,7 @@
         "open": "^10.1.2",
         "playwright-core": "1.59.0-alpha-2026-02-20",
         "tas-client": "0.3.1",
-        "undici": "^7.18.2",
+        "undici": "^7.24.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -20805,9 +20805,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
-      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-server.series/remote/package-lock.json
+++ b/package-lock-overrides/web-server.series/remote/package-lock.json
@@ -41,7 +41,6 @@
         "minimist": "^1.2.8",
         "node-pty": "^1.2.0-beta.10",
         "tas-client": "0.3.1",
-        "undici": "^7.18.2",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -1088,9 +1087,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/patches/common/build.diff
+++ b/patches/common/build.diff
@@ -26,34 +26,13 @@ Index: code-editor-src/package.json
      "minimist": "^1.2.8",
      "native-is-elevated": "0.9.0",
      "native-keymap": "^3.3.5",
-@@ -174,7 +173,7 @@
-     "css-loader": "^6.9.1",
-     "debounce": "^1.0.0",
-     "deemon": "^1.13.6",
--    "electron": "39.6.0",
-+    "electron": "40.6.0",
-     "eslint": "^9.36.0",
-     "eslint-formatter-compact": "^8.40.0",
-     "eslint-plugin-header": "3.1.1",
-@@ -238,9 +237,19 @@
+@@ -238,9 +237,6 @@
    },
    "overrides": {
      "node-gyp-build": "4.8.1",
 -    "kerberos@2.1.1": {
 -      "node-addon-api": "7.1.0"
-+    "@types/node-fetch@^2.5.12": {
-+      "form-data": "^3.0.4"
-     },
-+    "@azure/core-http@^2.3.2": {
-+      "form-data": "^4.0.4"
-+    },
-+    "braces": "^3.0.3",
-+    "@vscode/test-web": {
-+      "tar-fs": "^3.1.1",
-+      "koa": "^3.0.3"
-+    },
-+    "postcss": "^8.4.31",
-+    "playwright": "^1.55.1",
+-    },
      "serialize-javascript": "^7.0.3"
    },
    "repository": {
@@ -61,7 +40,7 @@ Index: code-editor-src/remote/package.json
 ===================================================================
 --- code-editor-src.orig/remote/package.json
 +++ code-editor-src/remote/package.json
-@@ -32,10 +32,10 @@
+@@ -32,7 +32,6 @@
      "https-proxy-agent": "^7.0.2",
      "jschardet": "3.1.4",
      "katex": "^0.16.22",
@@ -69,18 +48,14 @@ Index: code-editor-src/remote/package.json
      "minimist": "^1.2.8",
      "node-pty": "^1.2.0-beta.10",
      "tas-client": "0.3.1",
-+    "undici": "^7.18.2",
-     "vscode-oniguruma": "1.7.0",
-     "vscode-regexpp": "^3.1.0",
-     "vscode-textmate": "^9.3.2",
-@@ -44,8 +44,6 @@
+@@ -44,8 +43,5 @@
    },
    "overrides": {
-     "node-gyp-build": "4.8.1",
+-    "node-gyp-build": "4.8.1",
 -    "kerberos@2.1.1": {
 -      "node-addon-api": "7.1.0"
 -    }
-+    "@tootallnate/once": "^3.0.1"
++    "node-gyp-build": "4.8.1"
    }
  }
 Index: code-editor-src/build/lib/mangle/index.ts

--- a/patches/common/finding-overrides.diff
+++ b/patches/common/finding-overrides.diff
@@ -1,0 +1,46 @@
+Addresses npm dependency updates related to findings via version updates and overrides.
+
+Index: code-editor-src/package.json
+===================================================================
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
+@@ -121,7 +121,7 @@
+     "open": "^10.1.2",
+     "playwright-core": "1.59.0-alpha-2026-02-20",
+     "tas-client": "0.3.1",
+-    "undici": "^7.18.2",
++    "undici": "^7.24.0",
+     "v8-inspect-profiler": "^0.1.1",
+     "vscode-oniguruma": "1.7.0",
+     "vscode-regexpp": "^3.1.0",
+@@ -173,7 +173,7 @@
+     "css-loader": "^6.9.1",
+     "debounce": "^1.0.0",
+     "deemon": "^1.13.6",
+-    "electron": "39.6.0",
++    "electron": "40.6.0",
+     "eslint": "^9.36.0",
+     "eslint-formatter-compact": "^8.40.0",
+     "eslint-plugin-header": "3.1.1",
+@@ -236,6 +236,9 @@
+     "yaserver": "^0.4.0"
+   },
+   "overrides": {
++    "braces": "^3.0.3",
++    "postcss": "^8.4.31",
++    "@tootallnate/once": "^3.0.1",
+     "node-gyp-build": "4.8.1",
+     "serialize-javascript": "^7.0.3"
+   },
+Index: code-editor-src/remote/package.json
+===================================================================
+--- code-editor-src.orig/remote/package.json
++++ code-editor-src/remote/package.json
+@@ -42,6 +42,7 @@
+     "yazl": "^2.4.3"
+   },
+   "overrides": {
++    "undici": "^7.24.0",
+     "node-gyp-build": "4.8.1"
+   }
+ }

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -17,6 +17,7 @@ common/proposed-api.diff
 common/build.diff
 common/integration.diff
 common/fix-ts-rootdir-webpack.diff
+common/finding-overrides.diff
 common/fix-chat-debug-editor-visibility.diff
 web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -17,6 +17,7 @@ common/proposed-api.diff
 common/build.diff
 common/integration.diff
 common/fix-ts-rootdir-webpack.diff
+common/finding-overrides.diff
 common/fix-chat-debug-editor-visibility.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -17,6 +17,7 @@ common/proposed-api.diff
 common/build.diff
 common/integration.diff
 common/fix-ts-rootdir-webpack.diff
+common/finding-overrides.diff
 common/fix-chat-debug-editor-visibility.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -17,6 +17,7 @@ common/proposed-api.diff
 common/build.diff
 common/integration.diff
 common/fix-ts-rootdir-webpack.diff
+common/finding-overrides.diff
 common/fix-chat-debug-editor-visibility.diff
 web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff


### PR DESCRIPTION
Remove stale overrides
Split build-related package removals from finding related dependency overrides

## Issue
- V2141838229
- V2140617278



## Description of Changes
- Update undici to 7.24.0+
- Remove stale overrides which are not applicable in latest upstream

## Testing
- Workflow run on fork: https://github.com/azmkercso/code-editor/actions/runs/23290095821


## Screenshots/Videos
N/A


## Additional Notes
N/A


## Backporting
Will be backported to `1.1` and `1.0` as separate PRs.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.