### PR TITLE
fix(deps): Update picomatch, follow-redirects, and brace-expansion

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -4557,7 +4557,7 @@ THE SOFTWARE.
 ******************************
 
 follow-redirects
-1.15.11 <https://github.com/follow-redirects/follow-redirects>
+1.16.0 <https://github.com/follow-redirects/follow-redirects>
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -5925,7 +5925,7 @@ SOFTWARE.
 ******************************
 
 picomatch
-2.3.1 <https://github.com/micromatch/picomatch>
+2.3.2 <https://github.com/micromatch/picomatch>
 The MIT License (MIT)
 
 Copyright (c) 2017-present, Jon Schlinkert.

--- a/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
@@ -85,15 +85,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/chalk": {

--- a/build-tools/oss-attribution/oss-attribution-generator/package.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package.json
@@ -3,6 +3,7 @@
     "@electrovir/oss-attribution-generator": "2.0.0"
   },
   "overrides": {
-    "minimatch": "^10.2.3"
+    "minimatch": "^10.2.3",
+    "brace-expansion": "^5.0.5"
   }
 }

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -4557,7 +4557,7 @@ THE SOFTWARE.
 ******************************
 
 follow-redirects
-1.15.11 <https://github.com/follow-redirects/follow-redirects>
+1.16.0 <https://github.com/follow-redirects/follow-redirects>
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -5925,7 +5925,7 @@ SOFTWARE.
 ******************************
 
 picomatch
-2.3.1 <https://github.com/micromatch/picomatch>
+2.3.2 <https://github.com/micromatch/picomatch>
 The MIT License (MIT)
 
 Copyright (c) 2017-present, Jon Schlinkert.

--- a/package-lock-overrides/sagemaker.series/extensions/post-startup-notifications/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/extensions/post-startup-notifications/package-lock.json
@@ -5988,9 +5988,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -7359,9 +7359,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -13081,9 +13081,10 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/package-lock-overrides/sagemaker.series/remote/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/remote/package-lock.json
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -705,9 +705,10 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA= sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -13043,9 +13043,10 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
@@ -664,9 +664,10 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA= sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -13043,9 +13043,10 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/package-lock-overrides/web-embedded.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/remote/package-lock.json
@@ -664,9 +664,10 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA= sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -7372,9 +7372,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -13095,9 +13095,10 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/package-lock-overrides/web-server.series/remote/package-lock.json
+++ b/package-lock-overrides/web-server.series/remote/package-lock.json
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -705,9 +705,10 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA= sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/patches/common/override-follow-redirects.diff
+++ b/patches/common/override-follow-redirects.diff
@@ -1,0 +1,29 @@
+Description: Override follow-redirects to ^1.16.0 to fix GHSA-r4q5-vmmm-2653 (custom header leak on cross-domain redirect)
+Author: Amazon Web Services
+Index: b/package.json
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -240,7 +240,8 @@
+     "postcss": "^8.4.31",
+     "playwright": "^1.55.1",
+     "@tootallnate/once": "^3.0.1",
+-    "picomatch": "^2.3.2"
++    "picomatch": "^2.3.2",
++    "follow-redirects": "^1.16.0"
+   },
+   "repository": {
+     "type": "git",
+Index: b/remote/package.json
+===================================================================
+--- a/remote/package.json
++++ b/remote/package.json
+@@ -45,6 +45,7 @@
+   "overrides": {
+     "node-gyp-build": "4.8.1",
+     "@tootallnate/once": "^3.0.1",
+-    "picomatch": "^2.3.2"
++    "picomatch": "^2.3.2",
++    "follow-redirects": "^1.16.0"
+   }
+ }

--- a/patches/common/override-picomatch.diff
+++ b/patches/common/override-picomatch.diff
@@ -1,0 +1,29 @@
+Description: Override picomatch to ^2.3.2 to fix CVE-2026-33671 (ReDoS) and CVE-2026-33672 (method injection)
+Author: Amazon Web Services
+Index: b/package.json
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -239,7 +239,8 @@
+     },
+     "postcss": "^8.4.31",
+     "playwright": "^1.55.1",
+-    "@tootallnate/once": "^3.0.1"
++    "@tootallnate/once": "^3.0.1",
++    "picomatch": "^2.3.2"
+   },
+   "repository": {
+     "type": "git",
+Index: b/remote/package.json
+===================================================================
+--- a/remote/package.json
++++ b/remote/package.json
+@@ -44,6 +44,7 @@
+   },
+   "overrides": {
+     "node-gyp-build": "4.8.1",
+-    "@tootallnate/once": "^3.0.1"
++    "@tootallnate/once": "^3.0.1",
++    "picomatch": "^2.3.2"
+   }
+ }

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -19,6 +19,8 @@ common/integration.diff
 common/replace-gulp-untar.diff
 common/fix-ts-rootdir-webpack.diff
 common/fix-terminal-autoreplies.diff
+common/override-picomatch.diff
+common/override-follow-redirects.diff
 web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff
 web-server/base-path.diff
@@ -44,3 +46,4 @@ sagemaker/sagemaker-extensions-sync.diff
 sagemaker/fix-port-forwarding.diff
 sagemaker/display-both-versions-in-about.diff
 sagemaker/validate-http-request-referer.diff
+sagemaker/override-picomatch-post-startup-notifications.diff

--- a/patches/sagemaker/override-picomatch-post-startup-notifications.diff
+++ b/patches/sagemaker/override-picomatch-post-startup-notifications.diff
@@ -1,0 +1,16 @@
+Description: Override picomatch to ^2.3.2 in post-startup-notifications extension to fix CVE-2026-33671 and CVE-2026-33672
+Author: Amazon Web Services
+Index: b/extensions/post-startup-notifications/package.json
+===================================================================
+--- a/extensions/post-startup-notifications/package.json
++++ b/extensions/post-startup-notifications/package.json
+@@ -51,6 +51,9 @@
+         "webpack": "^5.98.0",
+         "webpack-cli": "^6.0.1"
+     },
++    "overrides": {
++        "picomatch": "^2.3.2"
++    },
+     "dependencies": {
+         "chokidar": "^4.0.3"
+     }

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -19,6 +19,8 @@ common/integration.diff
 common/replace-gulp-untar.diff
 common/fix-ts-rootdir-webpack.diff
 common/fix-terminal-autoreplies.diff
+common/override-picomatch.diff
+common/override-follow-redirects.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -19,6 +19,8 @@ common/integration.diff
 common/replace-gulp-untar.diff
 common/fix-ts-rootdir-webpack.diff
 common/fix-terminal-autoreplies.diff
+common/override-picomatch.diff
+common/override-follow-redirects.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -19,6 +19,8 @@ common/integration.diff
 common/replace-gulp-untar.diff
 common/fix-ts-rootdir-webpack.diff
 common/fix-terminal-autoreplies.diff
+common/override-picomatch.diff
+common/override-follow-redirects.diff
 web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff
 web-server/base-path.diff


### PR DESCRIPTION
## Issue
V2157614353


## Description of Changes
Update transitive dependency overrides:
- picomatch to 2.3.2
- follow-redirects to 1.16.0
- brace-expansion to 5.0.5 (oss-attribution-generator)

Regenerate lockfiles and LICENSE-THIRD-PARTY.

🤖 Assisted by AI


## Testing
Ran https://github.com/azmkercso/code-editor/actions/runs/24455535605 on azmkercso/code-editor fork to verify that security scan workflow succeeded


## Screenshots/Videos
N/A


## Additional Notes
N/A


## Backporting

Yes, separate PRs are being created for each affected branch

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.