### PR TITLE
fix(proxy): Preserve query params in port forwarding proxy

### DIFF
--- a/patches/web-server/proxy-uri.diff
+++ b/patches/web-server/proxy-uri.diff
@@ -152,7 +152,7 @@ Index: code-editor-src/src/vs/server/node/proxyServer.ts
 +		return {
 +			base,
 +			port,
-+			target: url.resolve(`http://0.0.0.0:${port}/`, targetPathname),
++			target: url.resolve(`http://0.0.0.0:${port}/`, targetPathname + (sourceUrl.search ?? "")),
 +		};
 +	}
 +


### PR DESCRIPTION
## Issue

D432038937
V2156052063

## Description of Changes

Append sourceUrl.search to the proxy target URL so query parameters are forwarded to the localhost service during port forwarding.

## Testing

Local testing by adding query params of port forwarded server.

## Screenshots/Videos
N/A


## Additional Notes
N/A


## Backporting

Yes, separate PRs are created for each branch.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.