### PR TITLE
refactor(server): Remove unused delay-shutdown REST endpoint

### DIFF
--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -48,3 +48,4 @@ sagemaker/display-both-versions-in-about.diff
 sagemaker/validate-http-request-referer.diff
 sagemaker/override-picomatch-post-startup-notifications.diff
 sagemaker/sanitize-terminal-sendtext-paths.diff
+sagemaker/remove-delay-shutdown-endpoint.diff

--- a/patches/sagemaker/remove-delay-shutdown-endpoint.diff
+++ b/patches/sagemaker/remove-delay-shutdown-endpoint.diff
@@ -1,0 +1,37 @@
+Index: code-editor-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
+===================================================================
+--- code-editor-src.orig/src/vs/server/node/remoteExtensionHostAgentServer.ts
++++ code-editor-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
+@@ -158,13 +158,6 @@ class RemoteExtensionHostAgentServer ext
+ 			return void res.end(this._productService.commit || '');
+ 		}
+ 
+-		// Delay shutdown
+-		if (pathname === '/delay-shutdown') {
+-			this._delayShutdown();
+-			res.writeHead(200);
+-			return void res.end('OK');
+-		}
+-
+ 		if (!httpRequestHasValidConnectionToken(this._connectionToken, req, parsedUrl)) {
+ 			// invalid connection token
+ 			return serveError(req, res, 403, `Forbidden.`);
+@@ -630,18 +623,6 @@ class RemoteExtensionHostAgentServer ext
+ 		}
+ 	}
+ 
+-	/**
+-	 * If the server is in a shutdown timeout, cancel it and start over
+-	 */
+-	private _delayShutdown(): void {
+-		if (this.shutdownTimer) {
+-			console.log('Got delay-shutdown request while in shutdown timeout, delaying');
+-			this._logService.info('Got delay-shutdown request while in shutdown timeout, delaying');
+-			this._cancelShutdown();
+-			this._waitThenShutdown();
+-		}
+-	}
+-
+ 	private _cancelShutdown(): void {
+ 		if (this.shutdownTimer) {
+ 			console.log('Cancelling previous shutdown timeout');


### PR DESCRIPTION
  ## Issue                                                                                                                                                                                    
                                                                                                                                                                                              
  P398067552                                                                                                                                                                                  
                                                                                                                                                                                              
  ## Description of Changes                                                                                                                                                                   
                                                                                                                                                                                              
  Remove the unused `/delay-shutdown` REST endpoint and its backing `_delayShutdown()` method from `remoteExtensionHostAgentServer.ts`.                                                       
                                                                                                                                                                                              
  This endpoint allowed callers to reset the auto-shutdown timer, indefinitely extending the lifetime of the Code Editor process even when there are no active connections. The feature is not
  used by the service — the shutdown lifecycle is fully managed by extension host connection events (`_onDidCloseExtHostConnection`).                                                         
                                                                                                                                                                                              
  The change is implemented as a quilt patch (`patches/sagemaker/remove-delay-shutdown-endpoint.diff`) appended to the end of `sagemaker.series`.                                             
                                                                                                                                                                                              
  ## Testing                                                                                                                                                                                  
                                                                                                                                                                                              
  - Verified all existing patches apply cleanly with the new patch appended (`prepare-src.sh code-editor-sagemaker-server` succeeds)                                                          
  - Confirmed no references to `delay-shutdown` or `_delayShutdown` remain in the patched source                                                                                              
  - Confirmed `_cancelShutdown()` and `_waitThenShutdown()` are preserved (still used by `_onDidCloseExtHostConnection`)                                                                      
  - Expected behavior after the change:                                                                                                                                                       
    - `GET /delay-shutdown` without connection token → `403 Forbidden` (previously `200 OK`)                                                                                                  
    - `GET /delay-shutdown` with valid connection token → `404 Not Found`                                                                                                                     
                                                                                                                                                                                              
  ## Screenshots/Videos                                                                                                                                                                       
                                                                                                                                                                                              
  N/A                                                                                                                                                                                         
                                                                                                                                                                                              
  ## Additional Notes                                                                                                                                                                         
                                                                                                                                                                                              
  - The `/delay-shutdown` handler was positioned before the connection token validation check, meaning it required no authentication                                                          
  - The auto-shutdown mechanism continues to work as before — it is triggered when the last extension host connection closes and runs on the `SHUTDOWN_TIMEOUT` timer                         
                                                                                                                                                                                              
  ## Backporting                                                                                                                                                                              
                                                                                                                                                                                              
  This change is submitted as separate PRs against all active release streams:                                                                                                                
  - `main`                                                                                                                                                                                    
  - `1.1`                                                                                                                                                                                     
  - `1.0`                                                                                                                                                                                     
                                                                                                                                                                                              
  ---                                                                                                                                                                                         
                                                                                                                                                                                              
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.