### PR TITLE
fix(security): Add path allowlisting to /vscode-remote-resource endpoint

### DIFF
--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -46,6 +46,7 @@ sagemaker/sagemaker-extensions-sync.diff
 sagemaker/fix-port-forwarding.diff
 sagemaker/display-both-versions-in-about.diff
 sagemaker/validate-http-request-referer.diff
+sagemaker/fix-path-traversal-vscode-remote-resource.diff
 sagemaker/override-picomatch-post-startup-notifications.diff
 sagemaker/sanitize-terminal-sendtext-paths.diff
 sagemaker/remove-delay-shutdown-endpoint.diff

--- a/patches/sagemaker/fix-path-traversal-vscode-remote-resource.diff
+++ b/patches/sagemaker/fix-path-traversal-vscode-remote-resource.diff
@@ -1,0 +1,31 @@
+Index: code-editor-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
+===================================================================
+--- code-editor-src.orig/src/vs/server/node/remoteExtensionHostAgentServer.ts
++++ code-editor-src/src/vs/server/node/remoteExtensionHostAgentServer.ts
+@@ -17,7 +17,7 @@ import { isSigPipeError, onUnexpectedErr
+ import { isEqualOrParent } from '../../base/common/extpath.js';
+ import { Disposable, DisposableStore } from '../../base/common/lifecycle.js';
+ import { connectionTokenQueryName, FileAccess, getServerProductSegment, Schemas } from '../../base/common/network.js';
+-import { dirname, join } from '../../base/common/path.js';
++import { dirname, join, resolve } from '../../base/common/path.js';
+ import * as perf from '../../base/common/performance.js';
+ import * as platform from '../../base/common/platform.js';
+ import { createRegExp, escapeRegExpCharacters } from '../../base/common/strings.js';
+@@ -191,6 +191,17 @@ class RemoteExtensionHostAgentServer ext
+ 				return serveError(req, res, 400, `Bad request.`);
+ 			}
+ 
++			// @secure_recommendation: Restrict file serving to allowed directories to prevent path traversal (P401260599)
++			const resolvedPath = resolve(filePath);
++			const allowedRoots = [
++				this._environmentService.builtinExtensionsPath,
++				this._environmentService.extensionsPath,
++				this._environmentService.userDataPath
++			];
++			if (!allowedRoots.some(root => isEqualOrParent(resolvedPath, root, !platform.isLinux))) {
++				return serveError(req, res, 403, `Forbidden.`);
++			}
++
+ 			const responseHeaders: Record<string, string> = Object.create(null);
+ 			if (this._environmentService.isBuilt) {
+ 				if (isEqualOrParent(filePath, this._environmentService.builtinExtensionsPath, !platform.isLinux)


### PR DESCRIPTION
## Issue
P401260599

## Description of Changes
Add path traversal protection to the /vscode-remote-resource handler. The endpoint previously served any file readable by the process with no path restriction, enabling arbitrary file read via ../ traversal, URL encoding, or direct absolute paths.

Changes:
- Import resolve from vs/base/common/path
- Resolve requested file path to canonical form before serving
- Validate resolved path against allowed directories (builtinExtensionsPath, extensionsPath, userDataPath)
- Return 403 Forbidden for paths outside allowed roots

## Testing
- Verified patch applies cleanly via quilt (prepare-src.sh)
- All subsequent patches in sagemaker.series apply without conflict

## Screenshots/Videos

## Additional Notes
Patch is placed after validate-http-request-referer.diff in the series, as it builds on the same handler code path.

## Backporting
This PR targets the 1.0 branch. A matching PR has been created for 1.1.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.