### PR TITLE
chore: Bump sagemakerCodeEditorVersion to 1.8.9

### DIFF
--- a/patches/sagemaker/display-both-versions-in-about.diff
+++ b/patches/sagemaker/display-both-versions-in-about.diff
@@ -33,7 +33,7 @@ Index: code-editor-src/product.json
  	"nameShort": "SageMaker Code Editor",
  	"nameLong": "SageMaker Code Editor",
  	"codeEditorVersion": "1.0.0",
-+	"sagemakerCodeEditorVersion":"1.8.8",
++	"sagemakerCodeEditorVersion":"1.8.9",
  	"applicationName": "code",
  	"dataFolderName": ".vscode-editor",
  	"win32MutexName": "vscodeoss",


### PR DESCRIPTION
Update the SageMaker Code Editor version in the about dialog patch from 1.8.8 to 1.8.9