### PR TITLE
chore: Bump sagemakerCodeEditorVersion to 1.9.6

### DIFF
--- a/patches/sagemaker/display-both-versions-in-about.diff
+++ b/patches/sagemaker/display-both-versions-in-about.diff
@@ -18,7 +18,7 @@ Index: code-editor-src/product.json
  	"nameShort": "SageMaker Code Editor",
  	"nameLong": "SageMaker Code Editor",
  	"codeEditorVersion": "1.0.0",
-+	"sagemakerCodeEditorVersion":"1.9.5",
++	"sagemakerCodeEditorVersion":"1.9.6",
  	"applicationName": "code",
  	"dataFolderName": ".vscode-editor",
  	"win32MutexName": "vscodeoss",


### PR DESCRIPTION
Update the SageMaker Code Editor version in the about dialog patch from 1.9.5 to 1.9.6