### PR TITLE
chore: override ip-address to ^10.1.1

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -5230,7 +5230,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************
 
 ip-address
-9.0.5 <https://github.com/beaugunderson/ip-address>
+10.2.0 <https://github.com/beaugunderson/ip-address>
 Copyright (C) 2011 by Beau Gunderson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -5394,52 +5394,6 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-******************************
-
-jsbn
-1.1.0 <https://github.com/andyperlitch/jsbn>
-Licensing
----------
-
-This software is covered under the following copyright:
-
-/*
- * Copyright (c) 2003-2005  Tom Wu
- * All Rights Reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND, 
- * EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY 
- * WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  
- *
- * IN NO EVENT SHALL TOM WU BE LIABLE FOR ANY SPECIAL, INCIDENTAL,
- * INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER OR NOT ADVISED OF
- * THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF LIABILITY, ARISING OUT
- * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * In addition, the following condition applies:
- *
- * All redistributions must retain an intact copy of this copyright notice
- * and disclaimer.
- */
-
-Address all questions regarding this license to:
-
-  Tom Wu
-  tjw@cs.Stanford.EDU
 
 
 ******************************
@@ -6589,36 +6543,6 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-******************************
-
-sprintf-js
-1.1.3 <https://github.com/alexei/sprintf.js>
-Copyright (c) 2007-present, Alexandru Mărășteanu <hello@alexei.ro>
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-* Neither the name of this software nor the names of its contributors may be
-  used to endorse or promote products derived from this software without
-  specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 ******************************
 

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -5230,7 +5230,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************
 
 ip-address
-9.0.5 <https://github.com/beaugunderson/ip-address>
+10.2.0 <https://github.com/beaugunderson/ip-address>
 Copyright (C) 2011 by Beau Gunderson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -5394,52 +5394,6 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-******************************
-
-jsbn
-1.1.0 <https://github.com/andyperlitch/jsbn>
-Licensing
----------
-
-This software is covered under the following copyright:
-
-/*
- * Copyright (c) 2003-2005  Tom Wu
- * All Rights Reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND, 
- * EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY 
- * WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  
- *
- * IN NO EVENT SHALL TOM WU BE LIABLE FOR ANY SPECIAL, INCIDENTAL,
- * INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER OR NOT ADVISED OF
- * THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF LIABILITY, ARISING OUT
- * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * In addition, the following condition applies:
- *
- * All redistributions must retain an intact copy of this copyright notice
- * and disclaimer.
- */
-
-Address all questions regarding this license to:
-
-  Tom Wu
-  tjw@cs.Stanford.EDU
 
 
 ******************************
@@ -6589,36 +6543,6 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-******************************
-
-sprintf-js
-1.1.3 <https://github.com/alexei/sprintf.js>
-Copyright (c) 2007-present, Alexandru Mărășteanu <hello@alexei.ro>
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-* Neither the name of this software nor the names of its contributors may be
-  used to endorse or promote products derived from this software without
-  specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 ******************************
 

--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -9601,13 +9601,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -10323,11 +10320,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -14681,7 +14673,9 @@
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/stable": {
       "version": "0.1.8",

--- a/package-lock-overrides/sagemaker.series/remote/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/remote/package-lock.json
@@ -826,13 +826,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -868,11 +865,6 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -1046,11 +1038,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/tas-client-umd": {
       "version": "0.2.0",

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -9565,13 +9565,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -10287,11 +10284,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -14647,7 +14639,9 @@
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/stable": {
       "version": "0.1.8",

--- a/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
@@ -785,13 +785,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -827,11 +824,6 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -999,11 +991,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/tas-client-umd": {
       "version": "0.2.0",

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -9565,13 +9565,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -10287,11 +10284,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -14647,7 +14639,9 @@
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/stable": {
       "version": "0.1.8",

--- a/package-lock-overrides/web-embedded.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/remote/package-lock.json
@@ -785,13 +785,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -827,11 +824,6 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -999,11 +991,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/tas-client-umd": {
       "version": "0.2.0",

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -9617,13 +9617,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -10339,11 +10336,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -14698,7 +14690,9 @@
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/stable": {
       "version": "0.1.8",

--- a/package-lock-overrides/web-server.series/remote/package-lock.json
+++ b/package-lock-overrides/web-server.series/remote/package-lock.json
@@ -826,13 +826,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -868,11 +865,6 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -1046,11 +1038,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/tas-client-umd": {
       "version": "0.2.0",

--- a/patches/common/finding-override-ip-address.diff
+++ b/patches/common/finding-override-ip-address.diff
@@ -1,0 +1,36 @@
+Override ip-address to ^10.1.1.
+Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override global:ip-address=^10.1.1 --override remote/package.json@global:ip-address=^10.1.1
+Remove when upstream Code-OSS updates ip-address to >= 10.1.1.
+
+@generated
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override 'global:ip-address=^10.1.1' --override 'remote/package.json@global:ip-address=^10.1.1'
+@override-package: ip-address@^10.1.1
+
+Index: b/package.json
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -237,8 +237,8 @@
+     "@tootallnate/once": "^3.0.1",
+     "picomatch": "2.3.2",
+     "follow-redirects": "1.16.0",
+-    "uuid": "14.0.0"
+-
++    "uuid": "14.0.0",
++    "ip-address": "^10.1.1"
+   },
+   "repository": {
+     "type": "git",
+Index: b/remote/package.json
+===================================================================
+--- a/remote/package.json
++++ b/remote/package.json
+@@ -48,6 +48,7 @@
+     "@tootallnate/once": "^3.0.1",
+     "picomatch": "2.3.2",
+     "follow-redirects": "1.16.0",
+-    "uuid": "14.0.0"
++    "uuid": "14.0.0",
++    "ip-address": "^10.1.1"
+   }
+ }

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -26,6 +26,7 @@ web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff
 web-server/base-path.diff
 web-server/webview.diff
+common/finding-override-ip-address.diff
 web-server/marketplace.diff
 web-server/integration.diff
 web-server/embedding-events.diff

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -22,6 +22,7 @@ common/fix-terminal-autoreplies.diff
 common/override-picomatch-cve-2026-33671.diff
 common/override-follow-redirects-ghsa-r4q5.diff
 common/override-uuid-ghsa-w5hq.diff
+common/finding-override-ip-address.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -22,6 +22,7 @@ common/fix-terminal-autoreplies.diff
 common/override-picomatch-cve-2026-33671.diff
 common/override-follow-redirects-ghsa-r4q5.diff
 common/override-uuid-ghsa-w5hq.diff
+common/finding-override-ip-address.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -22,6 +22,7 @@ common/fix-terminal-autoreplies.diff
 common/override-picomatch-cve-2026-33671.diff
 common/override-follow-redirects-ghsa-r4q5.diff
 common/override-uuid-ghsa-w5hq.diff
+common/finding-override-ip-address.diff
 web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff
 web-server/base-path.diff

--- a/scripts/patches/apply-override.sh
+++ b/scripts/patches/apply-override.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# apply-override.sh — Generate or regenerate a quilt patch that overrides
+# npm package versions in package.json files.
+#
+# Usage:
+#   scripts/patches/apply-override.sh \
+#     --patch common/override-example.diff \
+#     --header 'Override example-pkg to ^2.0.0' \
+#     --override 'global:example-pkg=^2.0.0' \
+#     --override 'remote/package.json@global:example-pkg=^2.0.0'
+#
+# Override spec format: [FILE@]STRATEGY:PACKAGE=VERSION
+#   FILE       — target package.json (default: package.json)
+#   STRATEGY   — global | direct | direct-dev | nested
+#   PACKAGE    — npm package name
+#   VERSION    — semver spec (e.g. ^2.3.2)
+#
+# For nested: nested:PARENT:PACKAGE=VERSION
+#
+# This script is called by prepare-src.sh during rebase to regenerate
+# @generated patches that fail to apply after an upstream Code-OSS bump.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PATCHED_SRC="${ROOT_DIR}/code-editor-src"
+PATCHES_DIR="${ROOT_DIR}/patches"
+
+# ---------------------------------------------------------------------------
+# Parse CLI args
+# ---------------------------------------------------------------------------
+PATCH_NAME=""
+HEADER=""
+OVERRIDES=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --patch)    PATCH_NAME="$2"; shift 2 ;;
+        --header)   HEADER="$2"; shift 2 ;;
+        --override) OVERRIDES+=("$2"); shift 2 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PATCH_NAME" ]]; then echo "Error: --patch is required" >&2; exit 1; fi
+if [[ -z "$HEADER" ]]; then echo "Error: --header is required" >&2; exit 1; fi
+if [[ ${#OVERRIDES[@]} -eq 0 ]]; then echo "Error: at least one --override is required" >&2; exit 1; fi
+
+PATCH_ENTRY="${PATCH_NAME%.diff}.diff"
+PATCH_FILE="${PATCHES_DIR}/${PATCH_ENTRY}"
+
+# ---------------------------------------------------------------------------
+# Parse an override spec into: FILE, STRATEGY, PARENT, PACKAGE, VERSION
+# ---------------------------------------------------------------------------
+parse_spec() {
+    local spec="$1"
+    SPEC_FILE="package.json"
+    local rest="$spec"
+
+    # Check for FILE@ prefix
+    if [[ "$spec" == *"@"* ]]; then
+        local before_at="${spec%%@*}"
+        if [[ "$before_at" != *":"* ]]; then
+            SPEC_FILE="$before_at"
+            rest="${spec#*@}"
+        fi
+    fi
+
+    local strategy="${rest%%:*}"
+    local pkg_ver="${rest#*:}"
+    SPEC_STRATEGY="$strategy"
+    SPEC_PARENT=""
+
+    if [[ "$strategy" == "nested" ]]; then
+        # nested:PARENT:PACKAGE=VERSION
+        local after_nested="${rest#nested:}"
+        SPEC_PARENT="${after_nested%%:*}"
+        pkg_ver="${after_nested#*:}"
+    fi
+
+    SPEC_PACKAGE="${pkg_ver%%=*}"
+    SPEC_VERSION="${pkg_ver#*=}"
+}
+
+# ---------------------------------------------------------------------------
+# Apply a single override to a package.json using jq
+# ---------------------------------------------------------------------------
+apply_override() {
+    local file="$1"
+    local strategy="$2"
+    local parent="$3"
+    local package="$4"
+    local version="$5"
+    local abs_path="${PATCHED_SRC}/${file}"
+
+    if [[ ! -f "$abs_path" ]]; then
+        echo "Error: ${file} not found in code-editor-src/" >&2
+        exit 1
+    fi
+
+    case "$strategy" in
+        global)
+            jq --arg pkg "$package" --arg ver "$version" \
+                '.overrides[$pkg] = $ver' "$abs_path" > "${abs_path}.tmp"
+            ;;
+        direct)
+            jq --arg pkg "$package" --arg ver "$version" \
+                '.dependencies[$pkg] = $ver' "$abs_path" > "${abs_path}.tmp"
+            ;;
+        direct-dev)
+            jq --arg pkg "$package" --arg ver "$version" \
+                '.devDependencies[$pkg] = $ver' "$abs_path" > "${abs_path}.tmp"
+            ;;
+        nested)
+            jq --arg parent "$parent" --arg pkg "$package" --arg ver "$version" \
+                '.overrides[$parent][$pkg] = $ver' "$abs_path" > "${abs_path}.tmp"
+            ;;
+        *)
+            echo "Unknown strategy: $strategy" >&2; exit 1
+            ;;
+    esac
+
+    mv "${abs_path}.tmp" "$abs_path"
+    echo "  Applied: ${file} ${strategy}:${package}=${version}"
+}
+
+# ---------------------------------------------------------------------------
+# Build metadata header
+# ---------------------------------------------------------------------------
+build_metadata() {
+    local cli_args="--patch ${PATCH_ENTRY}"
+    for o in "${OVERRIDES[@]}"; do
+        cli_args+=" --override '${o}'"
+    done
+
+    echo "$HEADER"
+    echo ""
+    echo "@generated"
+    echo "@generator: scripts/patches/apply-override.sh ${cli_args}"
+
+    # Collect unique @override-package entries
+    local -A seen_pkg=()
+    for o in "${OVERRIDES[@]}"; do
+        parse_spec "$o"
+        [[ "$SPEC_STRATEGY" == "direct-dev" ]] && continue
+
+        local pkg_key="${SPEC_PACKAGE}@${SPEC_VERSION}"
+        if [[ -z "${seen_pkg[$pkg_key]:-}" ]]; then
+            seen_pkg[$pkg_key]=1
+            echo "@override-package: ${pkg_key}"
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if [[ ! -d "$PATCHED_SRC" ]]; then
+    echo "Error: code-editor-src/ does not exist. Run prepare-src.sh first." >&2
+    exit 1
+fi
+
+# Find the first series file for quilt env
+SERIES_FILE=$(find "$PATCHES_DIR" -maxdepth 1 -name "*.series" | head -1)
+if [[ -z "$SERIES_FILE" ]]; then
+    echo "Error: No series files found in patches/" >&2
+    exit 1
+fi
+
+export QUILT_PATCHES="$PATCHES_DIR"
+export QUILT_SERIES="$SERIES_FILE"
+
+PATCH_EXISTS=false
+[[ -f "$PATCH_FILE" ]] && PATCH_EXISTS=true
+
+pushd "$PATCHED_SRC" > /dev/null
+
+# Create or reset the patch
+if [[ "$PATCH_EXISTS" == false ]]; then
+    quilt pop -qa 2>/dev/null || true
+    quilt new "$PATCH_ENTRY"
+else
+    # Pop to this patch, then refresh will regenerate it
+    quilt pop -q "$PATCH_ENTRY" 2>/dev/null || true
+    quilt push -q "$PATCH_ENTRY" 2>/dev/null || true
+fi
+
+# Track and apply each override
+for o in "${OVERRIDES[@]}"; do
+    parse_spec "$o"
+    quilt add "$SPEC_FILE" 2>/dev/null || true
+    apply_override "$SPEC_FILE" "$SPEC_STRATEGY" "$SPEC_PARENT" "$SPEC_PACKAGE" "$SPEC_VERSION"
+done
+
+quilt refresh -p ab --no-timestamps
+
+popd > /dev/null
+
+# Write metadata header (strip any existing header to avoid duplicates)
+METADATA=$(build_metadata)
+# Strip existing header: everything before the first "Index:" or "---" diff marker
+PATCH_CONTENT=$(sed -n '/^Index:\|^--- /,$p' "$PATCH_FILE")
+printf '%s\n\n%s\n' "$METADATA" "$PATCH_CONTENT" > "$PATCH_FILE"
+
+# Push remaining patches
+pushd "$PATCHED_SRC" > /dev/null
+quilt push -a 2>/dev/null || true
+popd > /dev/null
+
+# Add to all series files if new
+if [[ "$PATCH_EXISTS" == false ]]; then
+    for sf in "$PATCHES_DIR"/*.series; do
+        if ! grep -q "^${PATCH_ENTRY}$" "$sf"; then
+            # Insert after last common/ entry
+            local_last=$(grep -n "^common/" "$sf" | tail -1 | cut -d: -f1)
+            if [[ -n "$local_last" ]]; then
+                sed -i "${local_last}a\\${PATCH_ENTRY}" "$sf"
+            else
+                echo "$PATCH_ENTRY" >> "$sf"
+            fi
+        fi
+    done
+fi
+
+echo ""
+echo "Patch created: ${PATCH_ENTRY}"


### PR DESCRIPTION
Override ip-address to ^10.1.1 to resolve a medium-severity finding in the nightly security scan.

## Changes
- Add `patches/common/finding-override-ip-address.diff` — global override for ip-address in `package.json` and `remote/package.json`
- Add `scripts/patches/apply-override.sh` — reusable script for generating override patches
- Regenerate all lockfiles and OSS attribution

## Testing
- [x] `prepare-src.sh` applies all patches cleanly for all targets
- [x] Lockfile validation confirms ip-address@10.2.0 across all 8 lockfiles
- [x] OSS attribution regenerated