### PR TITLE
ci: declare contents: read on gitsecrets workflow

### DIFF
--- a/.github/workflows/gitsecrets.yml
+++ b/.github/workflows/gitsecrets.yml
@@ -7,6 +7,9 @@ on:
       - '*.*'
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   git-secret-check:
     name: Git Secrets Scan


### PR DESCRIPTION
`gitsecrets.yml` runs `awslabs/git-secrets` to scan PR commits for accidentally-committed AWS credentials. It checkouts the PR, runs the scanner, and exits — no writes. `contents: read` is the right floor for the checkout step.