### PR TITLE
chore: backport mcp server editor configuration disclosure

### DIFF
--- a/patches/backported-patches.json
+++ b/patches/backported-patches.json
@@ -10,5 +10,31 @@
         "affected_versions": "<1.109.1",
         "patch_path": "common/fix-terminal-autoreplies.diff",
         "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-21523"
+    },
+    {
+        "finding_id": "CVE-2026-41613",
+        "affected_versions": "<1.119.1",
+        "patch_path": "common/fix-mcp-server-editor-disclosure.diff",
+        "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-41613"
+    },
+    {
+        "finding_id": "GHSA-9f6c-63gp-pwpf",
+        "affected_versions": "<1.119.1",
+        "patch_path": "common/fix-mcp-server-editor-disclosure.diff",
+        "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-9f6c-63gp-pwpf"
+    },
+    {
+        "finding_id": "CVE-2026-41109",
+        "affected_versions": "<1.119.1",
+        "patch_path": "N/A",
+        "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-41109",
+        "note": "Copilot extension not present in Code-OSS 1.108.2"
+    },
+    {
+        "finding_id": "GHSA-rg3f-8xq5-hwh6",
+        "affected_versions": "<1.119.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-rg3f-8xq5-hwh6",
+        "note": "Copilot extension not present in Code-OSS 1.108.2"
     }
 ]

--- a/patches/common/fix-mcp-server-editor-disclosure.diff
+++ b/patches/common/fix-mcp-server-editor-disclosure.diff
@@ -1,0 +1,69 @@
+Backport MCP server editor configuration disclosure from upstream Code-OSS.
+Remove when Code-OSS is updated to >= 1.119.1.
+
+@backported: https://github.com/microsoft/vscode/commit/be09b4c7a118ae389662646f4fb9dcaa84757521
+@finding-id: CVE-2026-41613 GHSA-9f6c-63gp-pwpf
+Index: b/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
+===================================================================
+--- a/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
++++ b/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
+@@ -735,6 +735,26 @@ export class McpServerEditor extends Edi
+ 				const argsValue = append(argsSection, $('code.config-value'));
+ 				argsValue.textContent = config.args.join(' ');
+ 			}
++
++			// Environment variables (if present)
++			if (config.env && Object.keys(config.env).length > 0) {
++				const envSection = append(container, $('.config-section'));
++				const envLabel = append(envSection, $('.config-label'));
++				envLabel.textContent = localize('environment', "Environment:");
++				const envValue = append(envSection, $('.config-value'));
++				for (const [key, value] of Object.entries(config.env)) {
++					append(envValue, $('code.env-entry', undefined, `${key}=${value ?? ''}`));
++				}
++			}
++
++			// Env file (if present)
++			if (config.envFile) {
++				const envFileSection = append(container, $('.config-section'));
++				const envFileLabel = append(envFileSection, $('.config-label'));
++				envFileLabel.textContent = localize('envFile', "Environment File:");
++				const envFileValue = append(envFileSection, $('code.config-value'));
++				envFileValue.textContent = config.envFile;
++			}
+ 		} else if (config.type === McpServerType.REMOTE) {
+ 			// URL
+ 			const urlSection = append(container, $('.config-section'));
+@@ -742,6 +762,17 @@ export class McpServerEditor extends Edi
+ 			urlLabel.textContent = localize('url', "URL:");
+ 			const urlValue = append(urlSection, $('code.config-value'));
+ 			urlValue.textContent = config.url;
++
++			// Headers (if present)
++			if (config.headers && Object.keys(config.headers).length > 0) {
++				const headersSection = append(container, $('.config-section'));
++				const headersLabel = append(headersSection, $('.config-label'));
++				headersLabel.textContent = localize('headers', "Headers:");
++				const headersValue = append(headersSection, $('.config-value'));
++				for (const [key, value] of Object.entries(config.headers)) {
++					append(headersValue, $('code.env-entry', undefined, `${key}: ${value ?? ''}`));
++				}
++			}
+ 		}
+ 	}
+ 
+Index: b/src/vs/workbench/contrib/mcp/browser/media/mcpServerEditor.css
+===================================================================
+--- a/src/vs/workbench/contrib/mcp/browser/media/mcpServerEditor.css
++++ b/src/vs/workbench/contrib/mcp/browser/media/mcpServerEditor.css
+@@ -25,6 +25,10 @@
+ 		word-break: break-all;
+ 	}
+ 
++	.config-value .env-entry {
++		display: block;
++	}
++
+ 	.no-config {
+ 		color: var(--vscode-descriptionForeground);
+ 		font-style: italic;

--- a/patches/common/fix-terminal-autoreplies.diff
+++ b/patches/common/fix-terminal-autoreplies.diff
@@ -1,7 +1,8 @@
-Backporting fix for GHSA-3pwg-f3hj-wp8p advisory: https://github.com/microsoft/vscode/security/advisories/GHSA-3pwg-f3hj-wp8p
+Backport terminal autoreply restriction from upstream Code-OSS.
+Remove when Code-OSS is updated to >= 1.109.1.
 
-Based on commit: https://github.com/microsoft/vscode/commit/670c6d9b2a6588cc90a1e347015966dc391795ba
-
+@backported: https://github.com/microsoft/vscode/commit/670c6d9b2a6588cc90a1e347015966dc391795ba
+@finding-id: CVE-2026-21523 GHSA-3pwg-f3hj-wp8p
 Index: code-editor-src/src/vs/workbench/contrib/terminalContrib/autoReplies/common/terminalAutoRepliesConfiguration.ts
 ===================================================================
 --- code-editor-src.orig/src/vs/workbench/contrib/terminalContrib/autoReplies/common/terminalAutoRepliesConfiguration.ts

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -27,6 +27,7 @@ web-server/local-storage.diff
 web-server/base-path.diff
 web-server/webview.diff
 common/finding-override-ip-address.diff
+common/fix-mcp-server-editor-disclosure.diff
 web-server/marketplace.diff
 web-server/integration.diff
 web-server/embedding-events.diff

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -23,6 +23,7 @@ common/override-picomatch.diff
 common/override-follow-redirects.diff
 common/override-uuid-ghsa-w5hq.diff
 common/finding-override-ip-address.diff
+common/fix-mcp-server-editor-disclosure.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -23,6 +23,7 @@ common/override-picomatch.diff
 common/override-follow-redirects.diff
 common/override-uuid-ghsa-w5hq.diff
 common/finding-override-ip-address.diff
+common/fix-mcp-server-editor-disclosure.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -23,6 +23,7 @@ common/override-picomatch.diff
 common/override-follow-redirects.diff
 common/override-uuid-ghsa-w5hq.diff
 common/finding-override-ip-address.diff
+common/fix-mcp-server-editor-disclosure.diff
 web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff
 web-server/base-path.diff


### PR DESCRIPTION
Backport MCP server editor configuration disclosure from upstream Code-OSS (commit be09b4c7).

## Changes
- Add `patches/common/fix-mcp-server-editor-disclosure.diff` — shows environment variables, env file, and headers in the MCP server editor deeplink install UI
- Update `patches/backported-patches.json` with all findings from the May 18 security scan
- Add `@backported` and `@finding-id` metadata to backported patch headers

## Testing
- [x] `prepare-src.sh` applies all patches cleanly for all 4 targets
- [x] No lockfile changes needed (source-only patch)