### PR TITLE
chore: suppress non-applicable advisories in backported-patches.json

### DIFF
--- a/patches/backported-patches.json
+++ b/patches/backported-patches.json
@@ -10,5 +10,33 @@
         "affected_versions": "<1.109.1",
         "patch_path": "common/fix-terminal-autoreplies.diff",
         "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-21523"
+    },
+    {
+        "finding_id": "GHSA-9f6c-63gp-pwpf",
+        "affected_versions": "<1.119.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-9f6c-63gp-pwpf",
+        "note": "vulnerable code path does not exist in Code-OSS 1.101.2"
+    },
+    {
+        "finding_id": "CVE-2026-41613",
+        "affected_versions": "<1.119.1",
+        "patch_path": "N/A",
+        "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-41613",
+        "note": "vulnerable code path does not exist in Code-OSS 1.101.2"
+    },
+    {
+        "finding_id": "CVE-2026-41109",
+        "affected_versions": "<1.119.1",
+        "patch_path": "N/A",
+        "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-41109",
+        "note": "Copilot extension does not exist in Code-OSS 1.101.2"
+    },
+    {
+        "finding_id": "GHSA-rg3f-8xq5-hwh6",
+        "affected_versions": "<1.119.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-rg3f-8xq5-hwh6",
+        "note": "Copilot extension does not exist in Code-OSS 1.101.2"
     }
 ]

--- a/patches/common/fix-terminal-autoreplies.diff
+++ b/patches/common/fix-terminal-autoreplies.diff
@@ -1,7 +1,8 @@
-Backporting fix for GHSA-3pwg-f3hj-wp8p advisory: https://github.com/microsoft/vscode/security/advisories/GHSA-3pwg-f3hj-wp8p
+Backport terminal autoreply restriction from upstream Code-OSS.
+Remove when Code-OSS is updated to >= 1.109.1.
 
-Based on commit: https://github.com/microsoft/vscode/commit/670c6d9b2a6588cc90a1e347015966dc391795ba
-
+@backported: https://github.com/microsoft/vscode/commit/670c6d9b2a6588cc90a1e347015966dc391795ba
+@finding-id: CVE-2026-21523 GHSA-3pwg-f3hj-wp8p
 Index: code-editor-src/src/vs/workbench/contrib/terminalContrib/autoReplies/common/terminalAutoRepliesConfiguration.ts
 ===================================================================
 --- code-editor-src.orig/src/vs/workbench/contrib/terminalContrib/autoReplies/common/terminalAutoRepliesConfiguration.ts


### PR DESCRIPTION
Register non-applicable security advisories from the May 18 security scan in `backported-patches.json` so the scan stops flagging them.

## Changes
- Update `patches/backported-patches.json` — add entries with `note` field for advisories where the vulnerable code path does not exist in Code-OSS 1.101.2
- Add `@backported` and `@finding-id` metadata to existing `fix-terminal-autoreplies.diff` header

## Testing
- [x] `prepare-src.sh` applies all patches cleanly
- [x] No code changes — metadata only