### PR TITLE
Fix production build

### DIFF
--- a/patches/web-server/suppress-known-errors-build-integration.diff
+++ b/patches/web-server/suppress-known-errors-build-integration.diff
@@ -91,3 +91,17 @@ Index: code-editor-src/build/gulpfile.reh.ts
  ];
  
  const serverResourceExcludes = [
+Index: code-editor-src/build/next/index.ts
+===================================================================
+--- code-editor-src.orig/build/next/index.ts
++++ code-editor-src/build/next/index.ts
+@@ -323,6 +323,9 @@ const serverResourcePatterns = [
+ 	'vs/workbench/contrib/terminal/common/scripts/psreadline/*.ps1xml',
+ 	'vs/workbench/contrib/terminal/common/scripts/psreadline/net6plus/*.dll',
+ 	'vs/workbench/contrib/terminal/common/scripts/psreadline/netstd/*.dll',
++
++	// Error handler
++	'vs/editor/common/errors/suppressedErrors.js',
+ ];
+ 
+ // Resources for server-web target (server + web UI)

--- a/scripts/build-artifacts.sh
+++ b/scripts/build-artifacts.sh
@@ -106,14 +106,16 @@ build() {
     local present_working_dir="$(pwd)"
     local build_src_dir="${present_working_dir}/code-editor-src"
     
-    local build_target="${code_oss_build_target_base}-min"
+    # core-ci always produces minified bundles, so packaging always uses -min-ci
+    local package_target="${code_oss_build_target_base}-min-ci"
     
-    echo "Building Code Editor with '$build_target' as target with ${max_space_size_mb} MiB allocated heap"
+    echo "Building Code Editor: core-ci + '${package_target}' with ${max_space_size_mb} MiB allocated heap"
     
     cd "$build_src_dir"
-    env \
-        NODE_OPTIONS="--max-old-space-size=${max_space_size_mb}" \
-        npm run gulp "$build_target"
+    env NODE_OPTIONS="--max-old-space-size=${max_space_size_mb}" \
+        npm run gulp core-ci
+    env NODE_OPTIONS="--max-old-space-size=${max_space_size_mb}" \
+        npm run gulp "$package_target"
     cd ..
 }
 

--- a/scripts/prepare-src.sh
+++ b/scripts/prepare-src.sh
@@ -152,6 +152,13 @@ prepare_patch_directory() {
     
     echo "Copying third party source to the patch directory"
     rsync -a "${PRESENT_WORKING_DIR}/third-party-src/" "${PATCHED_SRC_DIR}"
+    
+    # Replace submodule gitlink with a proper .git so build tooling can read the commit
+    local commit_hash
+    commit_hash=$(cd "${PRESENT_WORKING_DIR}/third-party-src" && git rev-parse HEAD)
+    rm -f "${PATCHED_SRC_DIR}/.git"
+    mkdir -p "${PATCHED_SRC_DIR}/.git"
+    echo "$commit_hash" > "${PATCHED_SRC_DIR}/.git/HEAD"
 }
 
 apply_patches() {


### PR DESCRIPTION
Use ESBuild based core-ci build target

## Issue
N/A

## Description of Changes
Use ESBuild based core-ci build target instead of legacy one
Add custom build changes to new build target


## Testing
Ran scripts/build-artifacts.sh successfully locally, and tested the minified build


## Screenshots/Videos
N/A


## Additional Notes
N/A


## Backporting
No, this should not be backported, other versions still use the legacy build system

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.