### PR TITLE
Improve host validation for web extension resource proxy

### DIFF
--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -53,3 +53,4 @@ sagemaker/fix-path-traversal-vscode-remote-resource.diff
 sagemaker/sanitize-terminal-sendtext-paths.diff
 sagemaker/override-picomatch-post-startup-notifications.diff
 sagemaker/remove-delay-shutdown-endpoint.diff
+sagemaker/fix-web-extension-resource-host-validation.diff

--- a/patches/sagemaker/fix-web-extension-resource-host-validation.diff
+++ b/patches/sagemaker/fix-web-extension-resource-host-validation.diff
@@ -1,0 +1,64 @@
+Improve host validation for web extension resource proxy
+
+Strengthen hostname validation for the web-extension-resource route
+to ensure requests are only proxied to the configured extension gallery.
+
+--- code-editor-src.orig/src/vs/server/node/webClientServer.ts
++++ code-editor-src/src/vs/server/node/webClientServer.ts
+@@ -46,6 +46,24 @@ const enum ServiceName {
+ }
+ 
+ /**
++ * Validates that a requested hostname matches the configured gallery hostname.
++ */
++function isAllowedExtensionResourceHost(templateHostname: string, requestedHostname: string): boolean {
++	if (!templateHostname || !requestedHostname) {
++		return false;
++	}
++
++	const normalizedTemplate = templateHostname.toLowerCase();
++	const normalizedRequested = requestedHostname.toLowerCase();
++
++	if (normalizedRequested === normalizedTemplate) {
++		return true;
++	}
++
++	return normalizedRequested.endsWith('.' + normalizedTemplate);
++}
++
++/**
+  * Return an error to the client.
+  */
+ export async function serveError(req: http.IncomingMessage, res: http.ServerResponse, errorCode: number, errorMessage: string): Promise<void> {
+@@ -183,6 +201,11 @@ export class WebClientServer {
+ 			}
+ 			if (pathname.startsWith(WEB_EXTENSION_PATH) && pathname.charCodeAt(WEB_EXTENSION_PATH.length) === CharCode.Slash) {
+ 				// extension resource support
++				const resourcePath = pathname.substring(WEB_EXTENSION_PATH.length + 1);
++				const requestedHost = resourcePath.substring(0, resourcePath.indexOf('/'));
++				if (!this._isAllowedWebExtensionResourceHost(requestedHost)) {
++					return serveError(req, res, 403, 'Request Forbidden');
++				}
+ 				return this._handleWebExtensionResource(req, res, pathname.substring(WEB_EXTENSION_PATH.length));
+ 			}
+ 
+@@ -612,6 +635,19 @@ export class WebClientServer {
+ 			}
+ 		}
+ 	}
++
++	private _isAllowedWebExtensionResourceHost(requestedHost: string): boolean {
++		if (!this._productService.extensionsGallery?.resourceUrlTemplate) {
++			return false;
++		}
++
++		try {
++			const templateUrl = new URL(this._productService.extensionsGallery.resourceUrlTemplate);
++			return isAllowedExtensionResourceHost(templateUrl.hostname, requestedHost);
++		} catch {
++			return false;
++		}
++	}
+ }
+ 
+ 

--- a/sagemaker-tests/web-extension-resource-host-validation.test.ts
+++ b/sagemaker-tests/web-extension-resource-host-validation.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import './test-framework';
+
+const PATCHED_VSCODE_DIR = join(process.cwd(), 'code-editor-src');
+
+describe('fix-web-extension-resource-host-validation.diff validation', () => {
+  test('webClientServer.ts should have host validation function', () => {
+    const filePath = join(PATCHED_VSCODE_DIR, 'src/vs/server/node/webClientServer.ts');
+
+    if (!existsSync(filePath)) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+
+    const content = readFileSync(filePath, 'utf8');
+
+    if (!content.includes('function isAllowedExtensionResourceHost(')) {
+      throw new Error('Expected isAllowedExtensionResourceHost function not found');
+    }
+
+    console.log('PASS: Host validation function found');
+  });
+
+  test('webClientServer.ts should validate hosts before proxying', () => {
+    const filePath = join(PATCHED_VSCODE_DIR, 'src/vs/server/node/webClientServer.ts');
+
+    if (!existsSync(filePath)) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+
+    const content = readFileSync(filePath, 'utf8');
+
+    if (!content.includes('_isAllowedWebExtensionResourceHost')) {
+      throw new Error('Expected host validation method not found');
+    }
+
+    console.log('PASS: Host validation method found');
+  });
+});


### PR DESCRIPTION
## Issue
<!-- Please add just the issue number (e.g., D316398873) - do not paste the full link -->
- P418404326


## Description of Changes
<!-- Provide a clear and concise description of what changes you made and why -->
- Strengthen hostname validation for the web-extension-resource route to ensure requests are only proxied to the configured extension gallery.

## Testing
<!-- Describe how you tested this change. -->

- Need to build the image and test it using Custom Image on Studio 

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate your changes or test results -->


## Additional Notes
<!-- Add any additional context, considerations, dependencies, or notes for reviewers -->
- NA 

## Backporting
<!-- Consider if this change needs to be back-ported to previous active versions. -->
<!-- If the change needs to be backported, then please create separate PRs for version branches
and create a new release if required. -->
- NA
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.