### PR TITLE
chore: override brace-expansion to ^5.0.6

### DIFF
--- a/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/build-tools/oss-attribution/oss-attribution-generator/package.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package.json
@@ -4,6 +4,6 @@
   },
   "overrides": {
     "minimatch": "^10.2.3",
-    "brace-expansion": "5.0.5"
+    "brace-expansion": "^5.0.6"
   }
 }


### PR DESCRIPTION
## Issue
V2217241807



## Description of Changes
override brace-expansion to ^5.0.6


## Testing
Regenerated lockfiles


## Screenshots/Videos
N/A


## Additional Notes
N/A


## Backporting
Yes, each branch is addressed separately

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.