### PR TITLE
Remove Q CLI pop-up notification from post-startup-notifications extension

### DIFF
--- a/patches/sagemaker/post-startup-notifications.diff
+++ b/patches/sagemaker/post-startup-notifications.diff
@@ -253,22 +253,12 @@ Index: code-editor-src/extensions/post-startup-notifications/src/extension.ts
 ===================================================================
 --- /dev/null
 +++ code-editor-src/extensions/post-startup-notifications/src/extension.ts
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,80 @@
 +import * as vscode from 'vscode';
 +import * as fs from 'fs';
 +import { POST_START_UP_STATUS_FILE, SERVICE_NAME_ENV_KEY, SERVICE_NAME_ENV_VALUE } from './constant';
 +import { StatusFile } from './types';
 +import * as chokidar from 'chokidar';
-+
-+// Simple method to check if user has seen a notification
-+function hasUserSeen(context: vscode.ExtensionContext, notificationId: string): boolean {
-+  return context.globalState.get(`notification_seen_${notificationId}`) === true;
-+}
-+
-+// Simple method to mark notification as seen
-+function markAsSeen(context: vscode.ExtensionContext, notificationId: string): void {
-+  context.globalState.update(`notification_seen_${notificationId}`, true);
-+}
 +
 +let previousStatus: string | undefined;
 +let watcher: chokidar.FSWatcher;
@@ -283,9 +273,6 @@ Index: code-editor-src/extensions/post-startup-notifications/src/extension.ts
 +    }
 +
 +    outputChannel = vscode.window.createOutputChannel('SageMaker Unified Studio Post Startup Notifications');
-+    
-+    // Show Q CLI notification if user hasn't seen it before
-+    showQCliNotification(context);
 +
 +    try {
 +        watcher = chokidar.watch(POST_START_UP_STATUS_FILE, {
@@ -337,30 +324,6 @@ Index: code-editor-src/extensions/post-startup-notifications/src/extension.ts
 +    }
 +};
 +
-+// Show Q CLI notification if user hasn't seen it before
-+function showQCliNotification(context: vscode.ExtensionContext): void {
-+    const notificationId = 'smus_q_cli_notification';
-+    const message = 'The Amazon Q Command Line Interface (CLI) is installed. You can now access AI-powered assistance in your terminal.';
-+    const link = 'https://docs.aws.amazon.com/sagemaker-unified-studio/latest/userguide/q-actions.html';
-+    const linkLabel = 'Learn More';
-+    
-+    if (!hasUserSeen(context, notificationId)) {
-+        outputChannel.appendLine("User has not seen the notification")
-+        // Show notification with Learn More button
-+        vscode.window.showInformationMessage(
-+            message,
-+            { modal: false },
-+            { title: linkLabel, isCloseAffordance: false }
-+        ).then((selection) => {
-+            if (selection && selection.title === linkLabel) {
-+                vscode.env.openExternal(vscode.Uri.parse(link));
-+            }
-+            
-+            // Mark as seen regardless of which button was clicked
-+            markAsSeen(context, notificationId);
-+        });
-+    }
-+}
 +
 +export function deactivate() {
 +    if (watcher) {
@@ -375,7 +338,7 @@ Index: code-editor-src/extensions/post-startup-notifications/src/test/extension.
 ===================================================================
 --- /dev/null
 +++ code-editor-src/extensions/post-startup-notifications/src/test/extension.test.ts
-@@ -0,0 +1,267 @@
+@@ -0,0 +1,209 @@
 +import * as vscode from 'vscode';
 +import * as fs from 'fs';
 +import * as chokidar from 'chokidar';
@@ -395,12 +358,6 @@ Index: code-editor-src/extensions/post-startup-notifications/src/test/extension.
 +        showErrorMessage: jest.fn(),
 +        showInformationMessage: jest.fn().mockReturnValue(Promise.resolve()),
 +        createOutputChannel: jest.fn()
-+    },
-+    env: {
-+        openExternal: jest.fn()
-+    },
-+    Uri: {
-+        parse: jest.fn(url => ({ toString: () => url }))
 +    }
 +}));
 +
@@ -579,59 +536,7 @@ Index: code-editor-src/extensions/post-startup-notifications/src/test/extension.
 +            expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
 +        });
 +    });
-+    describe('Q CLI Notification Tests', () => {
-+        test('should show Q CLI notification with Learn More button', () => {
-+            // Set up globalState to simulate first-time user
-+            (mockContext.globalState.get as jest.Mock).mockReturnValue(undefined);
-+            
-+            activate(mockContext);
-+            
-+            // Verify notification is shown with correct message and button
-+            expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-+                'The Amazon Q Command Line Interface (CLI) is installed. You can now access AI-powered assistance in your terminal.',
-+                { modal: false },
-+                { title: 'Learn More', isCloseAffordance: false }
-+            );
-+        });
-+        
-+        test('should open documentation when Learn More is clicked', async () => {
-+            // Set up globalState to simulate first-time user
-+            (mockContext.globalState.get as jest.Mock).mockReturnValue(undefined);
-+            
-+            // Mock the user clicking "Learn More"
-+            const mockSelection = { title: 'Learn More' };
-+            (vscode.window.showInformationMessage as jest.Mock).mockReturnValue(Promise.resolve(mockSelection));
-+            
-+            activate(mockContext);
-+            
-+            // Wait for the promise to resolve
-+            await new Promise(process.nextTick);
-+            
-+            // Verify the documentation link is opened
-+            expect(vscode.env.openExternal).toHaveBeenCalledWith(
-+                expect.objectContaining({
-+                    toString: expect.any(Function)
-+                })
-+            );
-+            
-+            // Verify notification is marked as seen
-+            expect(mockContext.globalState.update).toHaveBeenCalledWith(
-+                'notification_seen_smus_q_cli_notification', 
-+                true
-+            );
-+        });
-+        
-+        test('should not show notification if already seen', () => {
-+            // Set up globalState to simulate returning user who has seen notification
-+            (mockContext.globalState.get as jest.Mock).mockReturnValue(true);
-+            
-+            activate(mockContext);
-+            
-+            // Verify notification is not shown again
-+            expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
-+        });
-+    });
-+    
++
 +    describe('Deactivation Tests', () => {
 +        test('should cleanup resources properly', () => {
 +            activate(mockContext);


### PR DESCRIPTION
The Amazon Q CLI notification is no longer needed as a post-startup popup in SageMaker Unified Studio Code Editor.

## Issue
<!-- Please add just the issue number (e.g., D316398873) - do not paste the full link -->

## Description of Changes
<!-- Provide a clear and concise description of what changes you made and why -->
Remove the Q CLI pop-up notification ("The Amazon Q Command Line Interface (CLI) is installed...") from the post-startup-notifications extension. This removes the showQCliNotification function, its helper functions (hasUserSeen, markAsSeen), and associated unit tests. Post-startup script status notifications (error/in-progress) remain functional.

## Testing
<!-- Describe how you tested this change. -->
- Built modified extension as .vsix
- Replaced built-in extension in a Unified Studio Code Editor space
- Verified Q CLI notification no longer appears on server restart
- Verified post-startup error/in-progress notifications still work correctly

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate your changes or test results -->


## Additional Notes
<!-- Add any additional context, considerations, dependencies, or notes for reviewers -->
Change is limited to `/patches/sagemaker/post-startup-notifications.diff`

## Backporting
<!-- Consider if this change needs to be back-ported to previous active versions. -->
<!-- If the change needs to be backported, then please create separate PRs for version branches
and create a new release if required. -->
---
This change has been backported to branches main, 1.1, and 1.2 via separate PRs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.