### PR TITLE
feat: add background state monitoring and check unsaved work to idle shutdown detection

### DIFF
--- a/patches/sagemaker/sagemaker-idle-extension.diff
+++ b/patches/sagemaker/sagemaker-idle-extension.diff
@@ -4,6 +4,10 @@ Introduces a built-in extension that monitors user activity (file changes,
 editor selections, terminal interactions) and logs the last active timestamp
 to a local file. Provides an /api/idle endpoint for external idle detection.
 
+Also monitors background state on a 60-second interval: active VS Code tasks,
+debug sessions, and unsaved documents (text files and notebooks) are treated
+as activity signals that prevent idle shutdown.
+
 Index: code-editor-src/extensions/sagemaker-idle-extension/README.md
 ===================================================================
 --- /dev/null
@@ -97,16 +101,28 @@ Index: code-editor-src/extensions/sagemaker-idle-extension/src/extension.ts
 ===================================================================
 --- /dev/null
 +++ code-editor-src/extensions/sagemaker-idle-extension/src/extension.ts
-@@ -0,0 +1,58 @@
+@@ -0,0 +1,92 @@
 +import * as vscode from "vscode";
 +import * as fs from "fs";
 +import * as path from "path";
 +
++const CHECK_INTERVAL = 60000;
 +let idleFilePath: string;
++let backgroundStateInterval: ReturnType<typeof setInterval> | undefined;
 +
 +export function activate(context: vscode.ExtensionContext) {
 +	initializeIdleFilePath();
 +	registerEventListeners(context);
++	backgroundStateInterval = startMonitoringBackgroundState();
++
++	context.subscriptions.push({
++		dispose: () => {
++			if (backgroundStateInterval) {
++				clearInterval(backgroundStateInterval);
++				backgroundStateInterval = undefined;
++			}
++		}
++	});
 +}
 +
 +export function deactivate() {}
@@ -155,6 +171,28 @@ Index: code-editor-src/extensions/sagemaker-idle-extension/src/extension.ts
 +function updateLastActivityTimestamp() {
 +	const timestamp = new Date().toISOString();
 +	fs.writeFileSync(idleFilePath, timestamp);
++}
++
++/**
++ * Monitors background state (tasks, debug sessions, unsaved work) on an interval.
++ * Updates the idle file if any background activity is detected.
++ */
++function startMonitoringBackgroundState(): ReturnType<typeof setInterval> {
++	return setInterval(() => {
++		const hasActiveTasks = vscode.tasks.taskExecutions.length > 0;
++		const hasDebugSession = vscode.debug.activeDebugSession !== undefined;
++
++		const hasUnsavedText = vscode.workspace.textDocuments.some(
++			(doc) => doc.isDirty && (doc.uri.scheme === "file" || doc.uri.scheme === "untitled")
++		);
++		const hasUnsavedNotebooks = vscode.workspace.notebookDocuments.some(
++			(notebook) => notebook.isDirty
++		);
++
++		if (hasActiveTasks || hasDebugSession || hasUnsavedText || hasUnsavedNotebooks) {
++			updateLastActivityTimestamp();
++		}
++	}, CHECK_INTERVAL);
 +}
 \ No newline at end of file
 Index: code-editor-src/src/vs/server/node/webClientServer.ts

--- a/sagemaker-tests/sagemaker-idle-extension.test.ts
+++ b/sagemaker-tests/sagemaker-idle-extension.test.ts
@@ -41,18 +41,70 @@ describe('sagemaker-idle-extension.patch validation', () => {
 
   test('sagemaker-idle-extension should have package.json with correct name', () => {
     const filePath = join(PATCHED_VSCODE_DIR, 'extensions/sagemaker-idle-extension/package.json');
-    
+
     if (!existsSync(filePath)) {
       throw new Error(`File not found: ${filePath}`);
     }
-    
+
     const content = readFileSync(filePath, 'utf8');
     const packageJson = JSON.parse(content);
-    
+
     if (packageJson.name !== 'sagemaker-idle-extension') {
       throw new Error(`Expected extension name 'sagemaker-idle-extension', got: ${packageJson.name}`);
     }
-    
+
     console.log('PASS: SageMaker idle extension package.json is valid');
+  });
+
+  test('sagemaker-idle-extension should monitor background state (tasks, debug, unsaved work)', () => {
+    const filePath = join(PATCHED_VSCODE_DIR, 'extensions/sagemaker-idle-extension/src/extension.ts');
+
+    if (!existsSync(filePath)) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+
+    const content = readFileSync(filePath, 'utf8');
+
+    if (!content.includes('vscode.tasks.taskExecutions.length > 0')) {
+      throw new Error('Expected task execution check not found in extension.ts');
+    }
+
+    if (!content.includes('vscode.debug.activeDebugSession !== undefined')) {
+      throw new Error('Expected debug session check not found in extension.ts');
+    }
+
+    if (!content.includes('doc.isDirty')) {
+      throw new Error('Expected unsaved text document check not found in extension.ts');
+    }
+
+    if (!content.includes('vscode.workspace.notebookDocuments.some')) {
+      throw new Error('Expected unsaved notebook check not found in extension.ts');
+    }
+
+    if (!content.includes('startMonitoringBackgroundState')) {
+      throw new Error('Expected startMonitoringBackgroundState function not found in extension.ts');
+    }
+
+    console.log('PASS: SageMaker idle extension monitors background state');
+  });
+
+  test('sagemaker-idle-extension should clean up interval on dispose', () => {
+    const filePath = join(PATCHED_VSCODE_DIR, 'extensions/sagemaker-idle-extension/src/extension.ts');
+
+    if (!existsSync(filePath)) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+
+    const content = readFileSync(filePath, 'utf8');
+
+    if (!content.includes('clearInterval(backgroundStateInterval)')) {
+      throw new Error('Expected clearInterval cleanup not found in extension.ts');
+    }
+
+    if (!content.includes('context.subscriptions.push')) {
+      throw new Error('Expected subscription push for dispose not found in extension.ts');
+    }
+
+    console.log('PASS: SageMaker idle extension cleans up interval on dispose');
   });
 });


### PR DESCRIPTION
## Issue
P313447346

## Description of Changes
Adds background state monitoring to the SageMaker idle extension to complete the idle shutdown detection criteria. Previously, only 3 of 6 PM-required idle signals were implemented (file changes, file viewing, terminal interaction). This PR adds:

- **Active VS Code tasks detection** — `vscode.tasks.taskExecutions.length > 0`
- **Active debug sessions detection** — `vscode.debug.activeDebugSession !== undefined`
- **Unsaved text documents** — `vscode.workspace.textDocuments.some(doc => doc.isDirty)`
- **Unsaved notebooks** — `vscode.workspace.notebookDocuments.some(nb => nb.isDirty)`

These checks run on a 60-second interval (matching the existing terminal activity check) and update the idle timestamp file when activity is detected, preventing premature idle shutdown.

Notebook kernel detection is excluded as Code Editor does not run Jupyter kernels (unlike JupyterLab).

This aligns Code Editor idle detection with the Remote IDE implementation in aws-toolkit-vscode.

## Testing
- Unit tests added in `sagemaker-tests/sagemaker-idle-extension.test.ts` validating:
  - Background state monitoring code is present (tasks, debug, unsaved work checks)
  - Interval cleanup logic on dispose
- Manual testing:
  - Open a file, make edits without saving → `/api/idle` timestamp should keep updating
  - Run a VS Code task → timestamp should keep updating
  - Start a debug session → timestamp should keep updating
  - Save all files, stop tasks/debug → timestamp should stop updating after 60s

## Screenshots/Videos
N/A — backend-only change with no UI impact.

## Additional Notes
- The idle detection for "background processes" is scoped to VS Code tasks and debug sessions only. Processes spawned directly in the terminal (e.g., `python train.py`) are not tracked by this mechanism but are partially covered by the existing `/dev/pts` mtime check for terminal I/O activity.
- This implementation mirrors `startMonitoringBackgroundState()` from aws-toolkit-vscode (`packages/core/src/awsService/sagemaker/utils.ts`).

## Backporting
This change applies to the current active versions (1.0.x, 1.1.x). Backport PRs should be created for both version branches if this is accepted.