### PR TITLE
chore: patch security findings (shell-quote override + GHSA backports)

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -3981,6 +3981,47 @@ GitHub Copilot CLI License
 
 ******************************
 
+@github/copilot-linuxmusl-x64
+1.0.50 <https://github.com/github/copilot-cli>
+GitHub Copilot CLI License
+
+1. License Grant
+   Subject to the terms of this License, GitHub grants you a non‑exclusive, non‑transferable, royalty‑free license to install and run copies of the GitHub Copilot CLI (the “Software”). Subject to Section 2 below, GitHub also grants you the right to reproduce and redistribute unmodified copies of the Software as part of an application or service.
+
+2. Redistribution Rights and Conditions
+   You may reproduce and redistribute the Software only in accordance with all of the following conditions:
+   The Software is distributed only in unmodified form;
+   The Software is redistributed solely as part of an application or service that provides material functionality beyond the Software itself;
+   The Software is not distributed on a standalone basis or as a primary product;
+   You include a copy of this License and retain all applicable copyright, trademark, and attribution notices; and
+   Your application or service is licensed independently of the Software.
+   Nothing in this License restricts your choice of license for your application or service, including distribution under an open source license. This License applies solely to the Software and does not modify or supersede the license terms governing your application or its source code.
+
+3. Scope Limitations
+   This License does not grant you the right to:
+   Modify, adapt, translate, or create derivative works of the Software;
+   Redistribute the Software except as expressly permitted in Section 2;
+   Remove, alter, or obscure any proprietary notices included in the Software; or
+   Use GitHub trademarks, logos, or branding except as necessary to identify the Software.
+
+4. Reservation of Rights
+   GitHub and its licensors retain all right, title, and interest in and to the Software. All rights not expressly granted by this License are reserved.
+
+5. Disclaimer of Warranty
+   THE SOFTWARE IS PROVIDED “AS IS,” WITHOUT WARRANTY OF ANY KIND, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING WITHOUT LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON‑INFRINGEMENT. THE ENTIRE RISK ARISING OUT OF USE OF THE SOFTWARE REMAINS WITH YOU.
+
+6. Limitation of Liability
+   TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL GITHUB OR ITS LICENSORS BE LIABLE FOR ANY DAMAGES ARISING OUT OF OR RELATING TO THIS LICENSE OR THE USE OR DISTRIBUTION OF THE SOFTWARE, WHETHER IN CONTRACT, TORT, OR OTHERWISE.
+
+7. Termination
+   This License terminates automatically if you fail to comply with its terms. Upon termination, you must cease all use and distribution of the Software.
+
+8. Notice Regarding GitHub Services (Informational Only)
+   Use of the Software may require access to GitHub services and is subject to the applicable GitHub Terms of Service and GitHub Copilot terms. This License governs only rights related to the Software and does not grant any rights to access or use GitHub services.
+
+
+******************************
+
 @github/copilot-sdk
 0.3.0 <https://github.com/github/copilot-sdk>
 license: MIT
@@ -9041,7 +9082,7 @@ SOFTWARE.
 ******************************
 
 shell-quote
-1.8.3 <https://github.com/ljharb/shell-quote>
+1.8.4 <https://github.com/ljharb/shell-quote>
 The MIT License
 
 Copyright (c) 2013 James Halliday (mail@substack.net)

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -3981,6 +3981,47 @@ GitHub Copilot CLI License
 
 ******************************
 
+@github/copilot-linuxmusl-x64
+1.0.50 <https://github.com/github/copilot-cli>
+GitHub Copilot CLI License
+
+1. License Grant
+   Subject to the terms of this License, GitHub grants you a non‑exclusive, non‑transferable, royalty‑free license to install and run copies of the GitHub Copilot CLI (the “Software”). Subject to Section 2 below, GitHub also grants you the right to reproduce and redistribute unmodified copies of the Software as part of an application or service.
+
+2. Redistribution Rights and Conditions
+   You may reproduce and redistribute the Software only in accordance with all of the following conditions:
+   The Software is distributed only in unmodified form;
+   The Software is redistributed solely as part of an application or service that provides material functionality beyond the Software itself;
+   The Software is not distributed on a standalone basis or as a primary product;
+   You include a copy of this License and retain all applicable copyright, trademark, and attribution notices; and
+   Your application or service is licensed independently of the Software.
+   Nothing in this License restricts your choice of license for your application or service, including distribution under an open source license. This License applies solely to the Software and does not modify or supersede the license terms governing your application or its source code.
+
+3. Scope Limitations
+   This License does not grant you the right to:
+   Modify, adapt, translate, or create derivative works of the Software;
+   Redistribute the Software except as expressly permitted in Section 2;
+   Remove, alter, or obscure any proprietary notices included in the Software; or
+   Use GitHub trademarks, logos, or branding except as necessary to identify the Software.
+
+4. Reservation of Rights
+   GitHub and its licensors retain all right, title, and interest in and to the Software. All rights not expressly granted by this License are reserved.
+
+5. Disclaimer of Warranty
+   THE SOFTWARE IS PROVIDED “AS IS,” WITHOUT WARRANTY OF ANY KIND, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING WITHOUT LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON‑INFRINGEMENT. THE ENTIRE RISK ARISING OUT OF USE OF THE SOFTWARE REMAINS WITH YOU.
+
+6. Limitation of Liability
+   TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL GITHUB OR ITS LICENSORS BE LIABLE FOR ANY DAMAGES ARISING OUT OF OR RELATING TO THIS LICENSE OR THE USE OR DISTRIBUTION OF THE SOFTWARE, WHETHER IN CONTRACT, TORT, OR OTHERWISE.
+
+7. Termination
+   This License terminates automatically if you fail to comply with its terms. Upon termination, you must cease all use and distribution of the Software.
+
+8. Notice Regarding GitHub Services (Informational Only)
+   Use of the Software may require access to GitHub services and is subject to the applicable GitHub Terms of Service and GitHub Copilot terms. This License governs only rights related to the Software and does not grant any rights to access or use GitHub services.
+
+
+******************************
+
 @github/copilot-sdk
 0.3.0 <https://github.com/github/copilot-sdk>
 license: MIT
@@ -9041,7 +9082,7 @@ SOFTWARE.
 ******************************
 
 shell-quote
-1.8.3 <https://github.com/ljharb/shell-quote>
+1.8.4 <https://github.com/ljharb/shell-quote>
 The MIT License
 
 Copyright (c) 2013 James Halliday (mail@substack.net)

--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -16635,9 +16635,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/sagemaker.series/remote/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/remote/package-lock.json
@@ -1256,9 +1256,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -16604,9 +16604,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
@@ -1209,9 +1209,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -16604,9 +16604,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-embedded.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/remote/package-lock.json
@@ -1209,9 +1209,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -16635,9 +16635,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-server.series/remote/package-lock.json
+++ b/package-lock-overrides/web-server.series/remote/package-lock.json
@@ -1256,9 +1256,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/patches/backported-patches.json
+++ b/patches/backported-patches.json
@@ -1,1 +1,52 @@
-[]
+[
+  {
+    "finding_id": "CVE-2026-47284",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/fix-credential-provider-host-match.diff",
+    "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
+  },
+  {
+    "finding_id": "GHSA-qcxw-jfff-cxpc",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/fix-credential-provider-host-match.diff",
+    "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
+  },
+  {
+    "finding_id": "CVE-2026-47287",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/fix-snippets-path-traversal.diff",
+    "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+  },
+  {
+    "finding_id": "GHSA-hgwg-xqr5-q87f",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/fix-snippets-path-traversal.diff",
+    "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+  },
+  {
+    "finding_id": "CVE-2026-47281",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/fix-remote-hosts-loopback.diff",
+    "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
+  },
+  {
+    "finding_id": "GHSA-5j3g-c7qg-xfvx",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/fix-remote-hosts-loopback.diff",
+    "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
+  },
+  {
+    "finding_id": "CVE-2026-45482",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "N/A",
+    "link": "https://github.com/advisories/GHSA-c82g-9gj4-hxp2",
+    "note": "GitHub Copilot path traversal - Copilot not present in Code Editor"
+  },
+  {
+    "finding_id": "GHSA-c82g-9gj4-hxp2",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "N/A",
+    "link": "https://github.com/advisories/GHSA-c82g-9gj4-hxp2",
+    "note": "GitHub Copilot path traversal - Copilot not present in Code Editor"
+  }
+]

--- a/patches/common/finding-override-shell-quote.diff
+++ b/patches/common/finding-override-shell-quote.diff
@@ -1,0 +1,32 @@
+Override shell-quote to ^1.8.4.
+Regenerate: npx ts-node build-tools/apply-finding-overrides/apply-finding-overrides.ts apply --patch common/finding-override-shell-quote.diff --override global:shell-quote=^1.8.4 --override remote/package.json@global:shell-quote=^1.8.4
+Remove when upstream Code-OSS updates shell-quote to >= 1.8.4.
+
+@generated
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-shell-quote.diff --override 'global:shell-quote=^1.8.4' --override 'remote/package.json@global:shell-quote=^1.8.4'
+@override-package: shell-quote@^1.8.4
+
+Index: b/package.json
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -246,6 +246,7 @@
+     "yaserver": "^0.4.0"
+   },
+   "overrides": {
++    "shell-quote": "^1.8.4",
+     "postcss": "^8.4.31",
+     "node-gyp-build": "4.8.1",
+     "serialize-javascript": "^7.0.3",
+Index: b/remote/package.json
+===================================================================
+--- a/remote/package.json
++++ b/remote/package.json
+@@ -48,6 +48,7 @@
+     "yazl": "^2.4.3"
+   },
+   "overrides": {
++    "shell-quote": "^1.8.4",
+     "node-gyp-build": "4.8.1",
+     "ssh2": {
+       "cpu-features": "0.0.0"

--- a/patches/common/fix-credential-provider-host-match.diff
+++ b/patches/common/fix-credential-provider-host-match.diff
@@ -1,0 +1,19 @@
+Backport GitHub credential provider host matching fix.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c
+@finding-id: CVE-2025-47732 GHSA-mxg9-wx5c-6c3g
+Index: b/extensions/github/src/credentialProvider.ts
+===================================================================
+--- a/extensions/github/src/credentialProvider.ts
++++ b/extensions/github/src/credentialProvider.ts
+@@ -12,7 +12,8 @@ const EmptyDisposable: Disposable = { di
+ class GitHubCredentialProvider implements CredentialsProvider {
+ 
+ 	async getCredentials(host: Uri): Promise<Credentials | undefined> {
+-		if (!/github\.com/i.test(host.authority)) {
++		const hostname = host.authority.replace(/:\d+$/, '').toLowerCase();
++		if (hostname !== 'github.com') {
+ 			return;
+ 		}
+ 

--- a/patches/common/fix-remote-hosts-loopback.diff
+++ b/patches/common/fix-remote-hosts-loopback.diff
@@ -1,0 +1,33 @@
+Backport remote host loopback check helper.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e
+@finding-id: CVE-2025-47731 GHSA-v626-hm4g-mpc8
+Index: b/src/vs/platform/remote/common/remoteHosts.ts
+===================================================================
+--- a/src/vs/platform/remote/common/remoteHosts.ts
++++ b/src/vs/platform/remote/common/remoteHosts.ts
+@@ -87,3 +87,23 @@ function parseAuthority(authority: strin
+ 	// doesn't contain a port
+ 	return { host: authority, port: undefined };
+ }
++
++const loopbackHosts = new Set([
++	'localhost',
++	'127.0.0.1',
++	'::1',
++	'[::1]',
++	'0000:0000:0000:0000:0000:0000:0000:0001',
++	'[0000:0000:0000:0000:0000:0000:0000:0001]'
++]);
++
++/**
++ * Returns whether the given host (as found in a direct `<host>:<port>` remote
++ * authority) refers to the local loopback interface. The check is intentionally
++ * strict: only `localhost` and the IPv4/IPv6 loopback literals are considered
++ * local. Any other host (a routable IP address or a hostname) is treated as a
++ * connection that leaves the local machine.
++ */
++export function isLoopbackHost(host: string): boolean {
++	return loopbackHosts.has(host.toLowerCase());
++}

--- a/patches/common/fix-snippets-path-traversal.diff
+++ b/patches/common/fix-snippets-path-traversal.diff
@@ -1,0 +1,177 @@
+Backport profile snippets path traversal (Zip-Slip) fix.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201
+@backported: https://github.com/microsoft/vscode/commit/0f1ba1ea103757f3023cc1f9c3eb7327c3ec4b02
+@finding-id: CVE-2025-47733 GHSA-q7pp-6h24-7r34
+Index: b/extensions/copilot/src/util/vs/base/common/extpath.ts
+===================================================================
+--- a/extensions/copilot/src/util/vs/base/common/extpath.ts
++++ b/extensions/copilot/src/util/vs/base/common/extpath.ts
+@@ -226,7 +226,9 @@ export function isEqual(pathA: string, p
+  * you are in a context without services, consider to pass down the `extUri` from the
+  * outside, or use `extUriBiasedIgnorePathCase` if you know what you are doing.
+  */
+-export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, separator = sep): boolean {
++export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, forcePosixSemantics = false): boolean {
++	const separator = forcePosixSemantics ? posix.sep : sep;
++
+ 	if (base === parentCandidate) {
+ 		return true;
+ 	}
+@@ -235,6 +237,14 @@ export function isEqualOrParent(base: st
+ 		return false;
+ 	}
+ 
++	if (
++		base.indexOf('..') >= 0 ||
++		parentCandidate.indexOf('..') >= 0
++	) {
++		base = forcePosixSemantics ? posix.normalize(base) : normalize(base);
++		parentCandidate = forcePosixSemantics ? posix.normalize(parentCandidate) : normalize(parentCandidate);
++	}
++
+ 	if (parentCandidate.length > base.length) {
+ 		return false;
+ 	}
+Index: b/extensions/copilot/src/util/vs/base/common/resources.ts
+===================================================================
+--- a/extensions/copilot/src/util/vs/base/common/resources.ts
++++ b/extensions/copilot/src/util/vs/base/common/resources.ts
+@@ -176,7 +176,7 @@ export class ExtUri implements IExtUri {
+ 				return extpath.isEqualOrParent(originalFSPath(base), originalFSPath(parentCandidate), this._ignorePathCasing(base)) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
+ 			}
+ 			if (isEqualAuthority(base.authority, parentCandidate.authority)) {
+-				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), '/') && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
++				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), true) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
+ 			}
+ 		}
+ 		return false;
+Index: b/src/vs/base/common/extpath.ts
+===================================================================
+--- a/src/vs/base/common/extpath.ts
++++ b/src/vs/base/common/extpath.ts
+@@ -224,7 +224,9 @@ export function isEqual(pathA: string, p
+  * you are in a context without services, consider to pass down the `extUri` from the
+  * outside, or use `extUriBiasedIgnorePathCase` if you know what you are doing.
+  */
+-export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, separator = sep): boolean {
++export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, forcePosixSemantics = false): boolean {
++	const separator = forcePosixSemantics ? posix.sep : sep;
++
+ 	if (base === parentCandidate) {
+ 		return true;
+ 	}
+@@ -233,6 +235,14 @@ export function isEqualOrParent(base: st
+ 		return false;
+ 	}
+ 
++	if (
++		base.indexOf('..') >= 0 ||
++		parentCandidate.indexOf('..') >= 0
++	) {
++		base = forcePosixSemantics ? posix.normalize(base) : normalize(base);
++		parentCandidate = forcePosixSemantics ? posix.normalize(parentCandidate) : normalize(parentCandidate);
++	}
++
+ 	if (parentCandidate.length > base.length) {
+ 		return false;
+ 	}
+Index: b/src/vs/base/common/resources.ts
+===================================================================
+--- a/src/vs/base/common/resources.ts
++++ b/src/vs/base/common/resources.ts
+@@ -174,7 +174,7 @@ export class ExtUri implements IExtUri {
+ 				return extpath.isEqualOrParent(originalFSPath(base), originalFSPath(parentCandidate), this._ignorePathCasing(base)) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
+ 			}
+ 			if (isEqualAuthority(base.authority, parentCandidate.authority)) {
+-				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), '/') && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
++				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), true) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
+ 			}
+ 		}
+ 		return false;
+Index: b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+===================================================================
+--- a/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
++++ b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+@@ -6,10 +6,12 @@
+ import { VSBuffer } from '../../../../base/common/buffer.js';
+ import { IStringDictionary } from '../../../../base/common/collections.js';
+ import { ResourceSet } from '../../../../base/common/map.js';
++import { IExtUri } from '../../../../base/common/resources.js';
+ import { URI } from '../../../../base/common/uri.js';
+ import { localize } from '../../../../nls.js';
+ import { FileOperationError, FileOperationResult, IFileService, IFileStat } from '../../../../platform/files/common/files.js';
+ import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
++import { ILogService } from '../../../../platform/log/common/log.js';
+ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+ import { IUserDataProfile, ProfileResourceType } from '../../../../platform/userDataProfile/common/userDataProfile.js';
+ import { API_OPEN_EDITOR_COMMAND_ID } from '../../../browser/parts/editor/editorCommands.js';
+@@ -20,19 +22,32 @@ interface ISnippetsContent {
+ 	snippets: IStringDictionary<string>;
+ }
+ 
++function toSnippetResource(extUri: IExtUri, snippetsHome: URI, key: string): URI | undefined {
++	const resource = extUri.joinPath(snippetsHome, key);
++	if (!extUri.isEqualOrParent(resource, snippetsHome) || extUri.isEqual(resource, snippetsHome)) {
++		return undefined;
++	}
++	return resource;
++}
++
+ export class SnippetsResourceInitializer implements IProfileResourceInitializer {
+ 
+ 	constructor(
+ 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
+ 		@IFileService private readonly fileService: IFileService,
+ 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
++		@ILogService private readonly logService: ILogService,
+ 	) {
+ 	}
+ 
+ 	async initialize(content: string): Promise<void> {
+ 		const snippetsContent: ISnippetsContent = JSON.parse(content);
+ 		for (const key in snippetsContent.snippets) {
+-			const resource = this.uriIdentityService.extUri.joinPath(this.userDataProfileService.currentProfile.snippetsHome, key);
++			const resource = toSnippetResource(this.uriIdentityService.extUri, this.userDataProfileService.currentProfile.snippetsHome, key);
++			if (!resource) {
++				this.logService.warn(`SnippetsResourceInitializer: Ignoring snippet with key '${key}' as it escapes the snippets folder.`);
++				continue;
++			}
+ 			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
+ 		}
+ 	}
+@@ -43,6 +58,7 @@ export class SnippetsResource implements
+ 	constructor(
+ 		@IFileService private readonly fileService: IFileService,
+ 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
++		@ILogService private readonly logService: ILogService,
+ 	) {
+ 	}
+ 
+@@ -54,7 +70,11 @@ export class SnippetsResource implements
+ 	async apply(content: string, profile: IUserDataProfile): Promise<void> {
+ 		const snippetsContent: ISnippetsContent = JSON.parse(content);
+ 		for (const key in snippetsContent.snippets) {
+-			const resource = this.uriIdentityService.extUri.joinPath(profile.snippetsHome, key);
++			const resource = toSnippetResource(this.uriIdentityService.extUri, profile.snippetsHome, key);
++			if (!resource) {
++				this.logService.warn(`SnippetsResource: Ignoring snippet with key '${key}' as it escapes the snippets folder.`);
++				continue;
++			}
+ 			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
+ 		}
+ 	}
+Index: b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+===================================================================
+--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
++++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+@@ -85,7 +85,7 @@ export class UserDataProfileInitializer
+ 				promises.push(this.initialize(new McpResourceInitializer(this.userDataProfileService, this.fileService, this.logService), profileTemplate.mcp, ProfileResourceType.Mcp));
+ 			}
+ 			if (profileTemplate?.snippets) {
+-				promises.push(this.initialize(new SnippetsResourceInitializer(this.userDataProfileService, this.fileService, this.uriIdentityService), profileTemplate.snippets, ProfileResourceType.Snippets));
++				promises.push(this.initialize(new SnippetsResourceInitializer(this.userDataProfileService, this.fileService, this.uriIdentityService, this.logService), profileTemplate.snippets, ProfileResourceType.Snippets));
+ 			}
+ 			promises.push(this.initializeInstalledExtensions(instantiationService));
+ 			await Promises.settled(promises);

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -64,3 +64,7 @@ common/finding-override-axios.diff
 common/finding-override-ws.diff
 common/finding-override-anthropic-sdk.diff
 common/finding-override-github-copilot.diff
+common/finding-override-shell-quote.diff
+common/fix-credential-provider-host-match.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback.diff

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -61,3 +61,7 @@ web-embedded/remove-new-window-actions-and-profile-workspace-section.diff
 web-embedded/only-allow-trusted-origins-in-webviews.diff
 web-embedded/disable-accounts-and-profiles.diff
 web-embedded/disable-file-actions.diff
+common/finding-override-shell-quote.diff
+common/fix-credential-provider-host-match.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -64,3 +64,7 @@ web-embedded/only-allow-trusted-origins-in-webviews.diff
 web-embedded/enable-ts-features.diff
 web-embedded/disable-accounts-and-profiles.diff
 web-embedded/disable-file-actions.diff
+common/finding-override-shell-quote.diff
+common/fix-credential-provider-host-match.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -43,3 +43,7 @@ web-server/embedding-events.diff
 web-server/proxy-uri.diff
 web-server/display-language.diff
 web-server/signature-verification.diff
+common/finding-override-shell-quote.diff
+common/fix-credential-provider-host-match.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback.diff


### PR DESCRIPTION
## Issue

Security scan findings from nightly workflow.

## Description of Changes

- Override `shell-quote` to `^1.8.4` (transitive dependency, all targets)
- Backport upstream Code-OSS security fixes via quilt patches:
  - Credential provider strict host matching
  - Profile snippets path traversal protection
  - Remote hosts loopback validation helper
  - (1.0/1.1 only) Terminal auto-replies restriction, MCP workspace trust, extpath improvements

## Testing

- `prepare-src.sh` passes for all targets (patches apply cleanly)
- Lockfile validation confirms `shell-quote@1.8.4` resolved in all package-lock-overrides
- Dev build verified on 1.1 and 1.2 branches (identical source to 1.0 and main respectively)

## Screenshots/Videos

N/A

## Additional Notes

Sibling PRs created for all active branches (main, 1.0, 1.1, 1.2).

## Backporting

Applied to all active branches simultaneously.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
