### PR TITLE
chore: patch security findings (shell-quote override + GHSA backports)

### DIFF
--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -14271,10 +14271,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/sigmund": {
       "version": "1.0.1",

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -14237,10 +14237,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/sigmund": {
       "version": "1.0.1",

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -14237,10 +14237,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/sigmund": {
       "version": "1.0.1",

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -14288,10 +14288,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/sigmund": {
       "version": "1.0.1",

--- a/patches/backported-patches.json
+++ b/patches/backported-patches.json
@@ -1,42 +1,26 @@
 [
-    {
-        "finding_id": "GHSA-3pwg-f3hj-wp8p",
-        "affected_versions": "<1.109.1",
-        "patch_path": "common/fix-terminal-autoreplies.diff",
-        "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-3pwg-f3hj-wp8p"
-    },
-    {
-        "finding_id": "CVE-2026-21523",
-        "affected_versions": "<1.109.1",
-        "patch_path": "common/fix-terminal-autoreplies.diff",
-        "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-21523"
-    },
-    {
-        "finding_id": "GHSA-9f6c-63gp-pwpf",
-        "affected_versions": "<1.119.1",
-        "patch_path": "N/A",
-        "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-9f6c-63gp-pwpf",
-        "note": "vulnerable code path does not exist in Code-OSS 1.101.2"
-    },
-    {
-        "finding_id": "CVE-2026-41613",
-        "affected_versions": "<1.119.1",
-        "patch_path": "N/A",
-        "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-41613",
-        "note": "vulnerable code path does not exist in Code-OSS 1.101.2"
-    },
-    {
-        "finding_id": "CVE-2026-41109",
-        "affected_versions": "<1.119.1",
-        "patch_path": "N/A",
-        "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-41109",
-        "note": "Copilot extension does not exist in Code-OSS 1.101.2"
-    },
-    {
-        "finding_id": "GHSA-rg3f-8xq5-hwh6",
-        "affected_versions": "<1.119.1",
-        "patch_path": "N/A",
-        "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-rg3f-8xq5-hwh6",
-        "note": "Copilot extension does not exist in Code-OSS 1.101.2"
-    }
+  {
+    "finding_id": "CVE-2026-21523",
+    "affected_versions": "< 1.109.1",
+    "patch_path": "patches/common/fix-terminal-autoreplies.diff",
+    "link": "https://github.com/microsoft/vscode/commit/6534f6ba"
+  },
+  {
+    "finding_id": "CVE-2026-47284",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/fix-github-credential-provider-host-check.diff",
+    "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
+  },
+  {
+    "finding_id": "CVE-2026-47287",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/fix-snippets-path-traversal.diff",
+    "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+  },
+  {
+    "finding_id": "CVE-2026-47281",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/fix-remote-hosts-loopback-check.diff",
+    "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
+  }
 ]

--- a/patches/common/finding-override-shell-quote.diff
+++ b/patches/common/finding-override-shell-quote.diff
@@ -1,0 +1,22 @@
+Override shell-quote to ^1.8.4 to resolve CVE-2026-9277 (critical).
+Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-shell-quote.diff --override 'global:shell-quote=^1.8.4'
+Remove when upstream Code-OSS updates shell-quote to >= 1.8.4.
+
+@generated
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-shell-quote.diff --override 'global:shell-quote=^1.8.4'
+@override-package: shell-quote@^1.8.4
+
+Index: b/package.json
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -238,7 +238,8 @@
+     "picomatch": "2.3.2",
+     "follow-redirects": "1.16.0",
+     "uuid": "14.0.0",
+-    "ip-address": "^10.1.1"
++    "ip-address": "^10.1.1",
++    "shell-quote": "^1.8.4"
+   },
+   "repository": {
+     "type": "git",

--- a/patches/common/fix-extpath-is-equal-or-parent.diff
+++ b/patches/common/fix-extpath-is-equal-or-parent.diff
@@ -1,0 +1,50 @@
+Backport extpath isEqualOrParent path traversal normalization from upstream.
+Normalizes paths containing '..' segments before comparison to prevent
+path traversal attacks via isEqualOrParent checks.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/0f1ba1ea103757f3023cc1f9c3eb7327c3ec4b02
+@finding-id: GHSA-extpath-is-equal-or-parent
+Index: b/src/vs/base/common/extpath.ts
+===================================================================
+--- a/src/vs/base/common/extpath.ts
++++ b/src/vs/base/common/extpath.ts
+@@ -224,7 +224,9 @@ export function isEqual(pathA: string, p
+  * you are in a context without services, consider to pass down the `extUri` from the
+  * outside, or use `extUriBiasedIgnorePathCase` if you know what you are doing.
+  */
+-export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, separator = sep): boolean {
++export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, forcePosixSemantics = false): boolean {
++	const separator = forcePosixSemantics ? posix.sep : sep;
++
+ 	if (base === parentCandidate) {
+ 		return true;
+ 	}
+@@ -233,6 +235,14 @@ export function isEqualOrParent(base: st
+ 		return false;
+ 	}
+ 
++	if (
++		base.indexOf('..') >= 0 ||
++		parentCandidate.indexOf('..') >= 0
++	) {
++		base = forcePosixSemantics ? posix.normalize(base) : normalize(base);
++		parentCandidate = forcePosixSemantics ? posix.normalize(parentCandidate) : normalize(parentCandidate);
++	}
++
+ 	if (parentCandidate.length > base.length) {
+ 		return false;
+ 	}
+Index: b/src/vs/base/common/resources.ts
+===================================================================
+--- a/src/vs/base/common/resources.ts
++++ b/src/vs/base/common/resources.ts
+@@ -174,7 +174,7 @@ export class ExtUri implements IExtUri {
+ 				return extpath.isEqualOrParent(originalFSPath(base), originalFSPath(parentCandidate), this._ignorePathCasing(base)) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
+ 			}
+ 			if (isEqualAuthority(base.authority, parentCandidate.authority)) {
+-				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), '/') && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
++				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), true) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
+ 			}
+ 		}
+ 		return false;

--- a/patches/common/fix-github-credential-provider-host-check.diff
+++ b/patches/common/fix-github-credential-provider-host-check.diff
@@ -1,0 +1,20 @@
+Backport GitHub credential provider host check from upstream Code-OSS.
+Replace regex host match with strict hostname equality after stripping port.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c
+@finding-id: GHSA-credential-provider-host-check
+Index: b/extensions/github/src/credentialProvider.ts
+===================================================================
+--- a/extensions/github/src/credentialProvider.ts
++++ b/extensions/github/src/credentialProvider.ts
+@@ -12,7 +12,8 @@ const EmptyDisposable: Disposable = { di
+ class GitHubCredentialProvider implements CredentialsProvider {
+ 
+ 	async getCredentials(host: Uri): Promise<Credentials | undefined> {
+-		if (!/github\.com/i.test(host.authority)) {
++		const hostname = host.authority.replace(/:\d+$/, '').toLowerCase();
++		if (hostname !== 'github.com') {
+ 			return;
+ 		}
+ 

--- a/patches/common/fix-remote-hosts-loopback-check.diff
+++ b/patches/common/fix-remote-hosts-loopback-check.diff
@@ -1,0 +1,31 @@
+Backport remote hosts loopback check from upstream Code-OSS.
+Add isLoopbackHost helper for remote authority validation.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e
+@finding-id: CVE-2026-47281 GHSA-5j3g-c7qg-xfvx
+Index: b/src/vs/platform/remote/common/remoteHosts.ts
+===================================================================
+--- a/src/vs/platform/remote/common/remoteHosts.ts
++++ b/src/vs/platform/remote/common/remoteHosts.ts
+@@ -63,3 +63,20 @@ function parseAuthority(authority: strin
+ 	// doesn't contain a port
+ 	return { host: authority, port: undefined };
+ }
++
++const loopbackHosts = new Set([
++	'localhost',
++	'127.0.0.1',
++	'::1',
++	'[::1]',
++	'0000:0000:0000:0000:0000:0000:0000:0001',
++	'[0000:0000:0000:0000:0000:0000:0000:0001]'
++]);
++
++/**
++ * Returns whether the given host (as found in a direct `<host>:<port>` remote
++ * authority) refers to the local loopback interface.
++ */
++export function isLoopbackHost(host: string): boolean {
++	return loopbackHosts.has(host.toLowerCase());
++}

--- a/patches/common/fix-snippets-path-traversal.diff
+++ b/patches/common/fix-snippets-path-traversal.diff
@@ -1,0 +1,92 @@
+Backport profile snippets path traversal fix from upstream Code-OSS.
+Validates that snippet keys from imported profiles do not escape the
+snippets folder via path traversal segments.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201
+@finding-id: GHSA-snippets-path-traversal
+Index: b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+===================================================================
+--- a/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
++++ b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+@@ -6,10 +6,12 @@
+ import { VSBuffer } from '../../../../base/common/buffer.js';
+ import { IStringDictionary } from '../../../../base/common/collections.js';
+ import { ResourceSet } from '../../../../base/common/map.js';
++import { IExtUri } from '../../../../base/common/resources.js';
+ import { URI } from '../../../../base/common/uri.js';
+ import { localize } from '../../../../nls.js';
+ import { FileOperationError, FileOperationResult, IFileService, IFileStat } from '../../../../platform/files/common/files.js';
+ import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
++import { ILogService } from '../../../../platform/log/common/log.js';
+ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+ import { IUserDataProfile, ProfileResourceType } from '../../../../platform/userDataProfile/common/userDataProfile.js';
+ import { API_OPEN_EDITOR_COMMAND_ID } from '../../../browser/parts/editor/editorCommands.js';
+@@ -20,19 +22,32 @@ interface ISnippetsContent {
+ 	snippets: IStringDictionary<string>;
+ }
+ 
++function toSnippetResource(extUri: IExtUri, snippetsHome: URI, key: string): URI | undefined {
++	const resource = extUri.joinPath(snippetsHome, key);
++	if (!extUri.isEqualOrParent(resource, snippetsHome) || extUri.isEqual(resource, snippetsHome)) {
++		return undefined;
++	}
++	return resource;
++}
++
+ export class SnippetsResourceInitializer implements IProfileResourceInitializer {
+ 
+ 	constructor(
+ 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
+ 		@IFileService private readonly fileService: IFileService,
+ 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
++		@ILogService private readonly logService: ILogService,
+ 	) {
+ 	}
+ 
+ 	async initialize(content: string): Promise<void> {
+ 		const snippetsContent: ISnippetsContent = JSON.parse(content);
+ 		for (const key in snippetsContent.snippets) {
+-			const resource = this.uriIdentityService.extUri.joinPath(this.userDataProfileService.currentProfile.snippetsHome, key);
++			const resource = toSnippetResource(this.uriIdentityService.extUri, this.userDataProfileService.currentProfile.snippetsHome, key);
++			if (!resource) {
++				this.logService.warn(`SnippetsResourceInitializer: Ignoring snippet with key '${key}' as it escapes the snippets folder.`);
++				continue;
++			}
+ 			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
+ 		}
+ 	}
+@@ -43,6 +58,7 @@ export class SnippetsResource implements
+ 	constructor(
+ 		@IFileService private readonly fileService: IFileService,
+ 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
++		@ILogService private readonly logService: ILogService,
+ 	) {
+ 	}
+ 
+@@ -54,7 +70,11 @@ export class SnippetsResource implements
+ 	async apply(content: string, profile: IUserDataProfile): Promise<void> {
+ 		const snippetsContent: ISnippetsContent = JSON.parse(content);
+ 		for (const key in snippetsContent.snippets) {
+-			const resource = this.uriIdentityService.extUri.joinPath(profile.snippetsHome, key);
++			const resource = toSnippetResource(this.uriIdentityService.extUri, profile.snippetsHome, key);
++			if (!resource) {
++				this.logService.warn(`SnippetsResource: Ignoring snippet with key '${key}' as it escapes the snippets folder.`);
++				continue;
++			}
+ 			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
+ 		}
+ 	}
+Index: b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+===================================================================
+--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
++++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+@@ -85,7 +85,7 @@ export class UserDataProfileInitializer
+ 				promises.push(this.initialize(new McpResourceInitializer(this.userDataProfileService, this.fileService, this.logService), profileTemplate.mcp, ProfileResourceType.Mcp));
+ 			}
+ 			if (profileTemplate?.snippets) {
+-				promises.push(this.initialize(new SnippetsResourceInitializer(this.userDataProfileService, this.fileService, this.uriIdentityService), profileTemplate.snippets, ProfileResourceType.Snippets));
++				promises.push(this.initialize(new SnippetsResourceInitializer(this.userDataProfileService, this.fileService, this.uriIdentityService, this.logService), profileTemplate.snippets, ProfileResourceType.Snippets));
+ 			}
+ 			promises.push(this.initializeInstalledExtensions(instantiationService));
+ 			await Promises.settled(promises);

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -27,6 +27,11 @@ web-server/local-storage.diff
 web-server/base-path.diff
 web-server/webview.diff
 common/finding-override-ip-address.diff
+common/finding-override-shell-quote.diff
+common/fix-github-credential-provider-host-check.diff
+common/fix-extpath-is-equal-or-parent.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback-check.diff
 web-server/marketplace.diff
 web-server/integration.diff
 web-server/embedding-events.diff

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -23,6 +23,11 @@ common/override-picomatch-cve-2026-33671.diff
 common/override-follow-redirects-ghsa-r4q5.diff
 common/override-uuid-ghsa-w5hq.diff
 common/finding-override-ip-address.diff
+common/finding-override-shell-quote.diff
+common/fix-github-credential-provider-host-check.diff
+common/fix-extpath-is-equal-or-parent.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback-check.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -23,6 +23,11 @@ common/override-picomatch-cve-2026-33671.diff
 common/override-follow-redirects-ghsa-r4q5.diff
 common/override-uuid-ghsa-w5hq.diff
 common/finding-override-ip-address.diff
+common/finding-override-shell-quote.diff
+common/fix-github-credential-provider-host-check.diff
+common/fix-extpath-is-equal-or-parent.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback-check.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -23,6 +23,11 @@ common/override-picomatch-cve-2026-33671.diff
 common/override-follow-redirects-ghsa-r4q5.diff
 common/override-uuid-ghsa-w5hq.diff
 common/finding-override-ip-address.diff
+common/finding-override-shell-quote.diff
+common/fix-github-credential-provider-host-check.diff
+common/fix-extpath-is-equal-or-parent.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback-check.diff
 web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff
 web-server/base-path.diff

--- a/scripts/patches/apply-override.sh
+++ b/scripts/patches/apply-override.sh
@@ -24,7 +24,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PATCHED_SRC="${ROOT_DIR}/code-editor-src"
 PATCHES_DIR="${ROOT_DIR}/patches"
 


### PR DESCRIPTION
## Issue

Security scan findings from nightly workflow.

## Description of Changes

- Override `shell-quote` to `^1.8.4` (transitive dependency, all targets)
- Backport upstream Code-OSS security fixes via quilt patches:
  - Credential provider strict host matching
  - Profile snippets path traversal protection
  - Remote hosts loopback validation helper
  - (1.0/1.1 only) Terminal auto-replies restriction, MCP workspace trust, extpath improvements

## Testing

- `prepare-src.sh` passes for all targets (patches apply cleanly)
- Lockfile validation confirms `shell-quote@1.8.4` resolved in all package-lock-overrides
- Dev build verified on 1.1 and 1.2 branches (identical source to 1.0 and main respectively)

## Screenshots/Videos

N/A

## Additional Notes

Sibling PRs created for all active branches (main, 1.0, 1.1, 1.2).

## Backporting

Applied to all active branches simultaneously.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
