### PR TITLE
chore: patch security findings (shell-quote override + GHSA backports)

### DIFF
--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -14439,10 +14439,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/sigmund": {
       "version": "1.0.1",

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -14402,10 +14402,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/sigmund": {
       "version": "1.0.1",

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -14402,10 +14402,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/sigmund": {
       "version": "1.0.1",

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -14453,10 +14453,17 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/sigmund": {
       "version": "1.0.1",

--- a/patches/backported-patches.json
+++ b/patches/backported-patches.json
@@ -12,6 +12,12 @@
         "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-21523"
     },
     {
+        "finding_id": "CVE-2026-21518",
+        "affected_versions": "<1.109.1",
+        "patch_path": "common/fix-mcp-workspace-trust.diff",
+        "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-21518"
+    },
+    {
         "finding_id": "CVE-2026-41613",
         "affected_versions": "<1.119.1",
         "patch_path": "common/fix-mcp-server-editor-disclosure.diff",
@@ -36,5 +42,29 @@
         "patch_path": "N/A",
         "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-rg3f-8xq5-hwh6",
         "note": "Copilot extension not present in Code-OSS 1.108.2"
+    },
+    {
+        "finding_id": "GHSA-credential-provider-host-match",
+        "affected_versions": "<1.123.1",
+        "patch_path": "common/fix-github-credential-provider-host-match.diff",
+        "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
+    },
+    {
+        "finding_id": "GHSA-extpath-is-equal-or-parent",
+        "affected_versions": "<1.123.1",
+        "patch_path": "common/fix-extpath-is-equal-or-parent.diff",
+        "link": "https://github.com/microsoft/vscode/commit/0f1ba1ea103757f3023cc1f9c3eb7327c3ec4b02"
+    },
+    {
+        "finding_id": "GHSA-snippets-path-traversal",
+        "affected_versions": "<1.123.1",
+        "patch_path": "common/fix-snippets-path-traversal.diff",
+        "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+    },
+    {
+        "finding_id": "GHSA-remote-hosts-loopback",
+        "affected_versions": "<1.123.1",
+        "patch_path": "common/fix-remote-hosts-loopback-check.diff",
+        "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
     }
 ]

--- a/patches/common/finding-override-shell-quote.diff
+++ b/patches/common/finding-override-shell-quote.diff
@@ -1,0 +1,22 @@
+Override shell-quote to ^1.8.4.
+Regenerate: npx ts-node build-tools/apply-finding-overrides/apply-finding-overrides.ts apply --patch common/finding-override-shell-quote.diff --override global:shell-quote=^1.8.4
+Remove when upstream Code-OSS updates shell-quote to >= 1.8.4.
+
+@generated
+@generator: npx ts-node build-tools/apply-finding-overrides/apply-finding-overrides.ts apply --patch common/finding-override-shell-quote.diff --override global:shell-quote=^1.8.4
+@override-package: shell-quote@^1.8.4
+
+Index: b/package.json
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -243,7 +243,8 @@
+     "picomatch": "^2.3.2",
+     "follow-redirects": "^1.16.0",
+     "uuid": "^14.0.0",
+-    "ip-address": "^10.1.1"
++    "ip-address": "^10.1.1",
++    "shell-quote": "^1.8.4"
+   },
+   "repository": {
+     "type": "git",

--- a/patches/common/fix-extpath-is-equal-or-parent.diff
+++ b/patches/common/fix-extpath-is-equal-or-parent.diff
@@ -1,0 +1,50 @@
+Backport extpath isEqualOrParent path traversal normalization from upstream.
+Normalizes paths containing '..' segments before comparison to prevent
+path traversal attacks via isEqualOrParent checks.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/0f1ba1ea103757f3023cc1f9c3eb7327c3ec4b02
+@finding-id: GHSA-extpath-is-equal-or-parent
+Index: b/src/vs/base/common/extpath.ts
+===================================================================
+--- a/src/vs/base/common/extpath.ts
++++ b/src/vs/base/common/extpath.ts
+@@ -224,7 +224,9 @@ export function isEqual(pathA: string, p
+  * you are in a context without services, consider to pass down the `extUri` from the
+  * outside, or use `extUriBiasedIgnorePathCase` if you know what you are doing.
+  */
+-export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, separator = sep): boolean {
++export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, forcePosixSemantics = false): boolean {
++	const separator = forcePosixSemantics ? posix.sep : sep;
++
+ 	if (base === parentCandidate) {
+ 		return true;
+ 	}
+@@ -233,6 +235,14 @@ export function isEqualOrParent(base: st
+ 		return false;
+ 	}
+ 
++	if (
++		base.indexOf('..') >= 0 ||
++		parentCandidate.indexOf('..') >= 0
++	) {
++		base = forcePosixSemantics ? posix.normalize(base) : normalize(base);
++		parentCandidate = forcePosixSemantics ? posix.normalize(parentCandidate) : normalize(parentCandidate);
++	}
++
+ 	if (parentCandidate.length > base.length) {
+ 		return false;
+ 	}
+Index: b/src/vs/base/common/resources.ts
+===================================================================
+--- a/src/vs/base/common/resources.ts
++++ b/src/vs/base/common/resources.ts
+@@ -174,7 +174,7 @@ export class ExtUri implements IExtUri {
+ 				return extpath.isEqualOrParent(originalFSPath(base), originalFSPath(parentCandidate), this._ignorePathCasing(base)) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
+ 			}
+ 			if (isEqualAuthority(base.authority, parentCandidate.authority)) {
+-				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), '/') && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
++				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), true) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
+ 			}
+ 		}
+ 		return false;

--- a/patches/common/fix-github-credential-provider-host-match.diff
+++ b/patches/common/fix-github-credential-provider-host-match.diff
@@ -1,0 +1,20 @@
+Backport GitHub credential provider host matching fix from upstream Code-OSS.
+Use exact hostname comparison instead of regex to prevent subdomain spoofing.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c
+@finding-id: GHSA-credential-provider-host-match
+Index: b/extensions/github/src/credentialProvider.ts
+===================================================================
+--- a/extensions/github/src/credentialProvider.ts
++++ b/extensions/github/src/credentialProvider.ts
+@@ -12,7 +12,8 @@ const EmptyDisposable: Disposable = { di
+ class GitHubCredentialProvider implements CredentialsProvider {
+ 
+ 	async getCredentials(host: Uri): Promise<Credentials | undefined> {
+-		if (!/github\.com/i.test(host.authority)) {
++		const hostname = host.authority.replace(/:\d+$/, '').toLowerCase();
++		if (hostname !== 'github.com') {
+ 			return;
+ 		}
+ 

--- a/patches/common/fix-mcp-workspace-trust.diff
+++ b/patches/common/fix-mcp-workspace-trust.diff
@@ -1,0 +1,183 @@
+Backport MCP workspace trust requirement from upstream Code-OSS.
+Requires workspace trust before starting MCP servers defined in workspace
+files. Also adds punycode encoding utilities needed for MCP server URL
+validation.
+Remove when Code-OSS is updated to >= 1.109.1.
+
+@backported: https://github.com/microsoft/vscode/commit/cd11faec7b031b928bc5ec37f350d623ffb28713
+@finding-id: CVE-2026-21518
+Index: b/src/vs/base/common/strings.ts
+===================================================================
+--- a/src/vs/base/common/strings.ts
++++ b/src/vs/base/common/strings.ts
+@@ -1362,3 +1362,134 @@ function toBinary(str: string): string {
+ export function multibyteAwareBtoa(str: string): string {
+ 	return btoa(toBinary(str));
+ }
++
++//#region Punycode
++
++// RFC 3492 constants
++const enum PunycodeConstants {
++	BASE = 36,
++	TMIN = 1,
++	TMAX = 26,
++	SKEW = 38,
++	DAMP = 700,
++	INITIAL_BIAS = 72,
++	INITIAL_N = 128,
++	DELIMITER = CharCode.Dash
++}
++
++function encodePunycodeDigit(d: number): number {
++	return d < 26 ? CharCode.a + d : CharCode.Digit0 + d - 26;
++}
++
++function adaptPunycodeBias(delta: number, numPoints: number, firstTime: boolean): number {
++	delta = firstTime ? Math.floor(delta / PunycodeConstants.DAMP) : delta >> 1;
++	delta += Math.floor(delta / numPoints);
++
++	let k = 0;
++	const baseMinusTmin = PunycodeConstants.BASE - PunycodeConstants.TMIN;
++	while (delta > (baseMinusTmin * PunycodeConstants.TMAX) >> 1) {
++		delta = Math.floor(delta / baseMinusTmin);
++		k += PunycodeConstants.BASE;
++	}
++	return k + Math.floor((baseMinusTmin + 1) * delta / (delta + PunycodeConstants.SKEW));
++}
++
++export function punycodeEncode(input: string): string {
++	const output: number[] = [];
++
++	const codePoints: number[] = [];
++	const iterator = new CodePointIterator(input);
++	while (!iterator.eol()) {
++		const cp = iterator.nextCodePoint();
++		if (cp >= 0xD800 && cp <= 0xDFFF) {
++			throw new Error('Invalid surrogate pair in input');
++		}
++		codePoints.push(cp);
++	}
++
++	let basicCount = 0;
++	for (const cp of codePoints) {
++		if (cp < PunycodeConstants.INITIAL_N) {
++			output.push(cp);
++			basicCount++;
++		}
++	}
++
++	const handledCount = basicCount;
++	if (basicCount > 0 && basicCount < codePoints.length) {
++		output.push(PunycodeConstants.DELIMITER);
++	}
++
++	let n = PunycodeConstants.INITIAL_N;
++	let delta = 0;
++	let bias = PunycodeConstants.INITIAL_BIAS;
++	let h = handledCount;
++
++	while (h < codePoints.length) {
++		let m = 0x10FFFF;
++		for (const cp of codePoints) {
++			if (cp >= n && cp < m) {
++				m = cp;
++			}
++		}
++
++		const deltaIncrement = (m - n) * (h + 1);
++		if (delta > Number.MAX_SAFE_INTEGER - deltaIncrement) {
++			throw new Error('Punycode overflow');
++		}
++		delta += deltaIncrement;
++		n = m;
++
++		for (const cp of codePoints) {
++			if (cp < n) {
++				delta++;
++				if (delta === 0) {
++					throw new Error('Punycode overflow');
++				}
++			} else if (cp === n) {
++				let q = delta;
++				for (let k = PunycodeConstants.BASE; ; k += PunycodeConstants.BASE) {
++					const t = k <= bias ? PunycodeConstants.TMIN :
++						k >= bias + PunycodeConstants.TMAX ? PunycodeConstants.TMAX :
++							k - bias;
++					if (q < t) {
++						break;
++					}
++					const digit = t + ((q - t) % (PunycodeConstants.BASE - t));
++					output.push(encodePunycodeDigit(digit));
++					q = Math.floor((q - t) / (PunycodeConstants.BASE - t));
++				}
++				output.push(encodePunycodeDigit(q));
++				bias = adaptPunycodeBias(delta, h + 1, h === handledCount);
++				delta = 0;
++				h++;
++			}
++		}
++		delta++;
++		n++;
++	}
++
++	let ret = '';
++	for (const ch of output) {
++		ret += String.fromCharCode(ch);
++	}
++	return ret;
++}
++
++export function toPunycodeACE(label: string): string {
++	let hasNonASCII = false;
++	for (let i = 0; i < label.length; i++) {
++		if (label.charCodeAt(i) >= PunycodeConstants.INITIAL_N) {
++			hasNonASCII = true;
++			break;
++		}
++	}
++
++	if (!hasNonASCII) {
++		return label;
++	}
++
++	return 'xn--' + punycodeEncode(label);
++}
++
++//#endregion
+Index: b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+===================================================================
+--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
++++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+@@ -26,6 +26,7 @@ import { observableConfigValue } from '.
+ import { IQuickInputButton, IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+ import { StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+ import { IWorkspaceFolderData } from '../../../../platform/workspace/common/workspace.js';
++import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
+ import { IConfigurationResolverService } from '../../../services/configurationResolver/common/configurationResolver.js';
+ import { ConfigurationResolverExpression, IResolvedValue } from '../../../services/configurationResolver/common/configurationResolverExpression.js';
+ import { AUX_WINDOW_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
+@@ -85,6 +86,8 @@ export class McpRegistry extends Disposa
+ 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
+ 		@ILabelService private readonly _labelService: ILabelService,
+ 		@ILogService private readonly _logService: ILogService,
++		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
++		@IWorkspaceTrustRequestService private readonly _workspaceTrustRequestService: IWorkspaceTrustRequestService,
+ 	) {
+ 		super();
+ 		this._mcpAccessValue = observableConfigValue(mcpAccessConfig, McpAccessValue.All, configurationService);
+@@ -211,6 +214,14 @@ export class McpRegistry extends Disposa
+ 		autoTrustChanges = false,
+ 		errorOnUserInteraction = false,
+ 	}: IMcpResolveConnectionOptions) {
++		if (collection.scope === StorageScope.WORKSPACE && !this._workspaceTrustManagementService.isWorkspaceTrusted()) {
++			if (errorOnUserInteraction) {
++				throw new UserInteractionRequiredError('workspaceTrust');
++			} else if (!await this._workspaceTrustRequestService.requestWorkspaceTrust({ message: localize('runTrust', "This MCP server definition is defined in your workspace files.") })) {
++				return false;
++			}
++		}
++
+ 		if (collection.trustBehavior === McpServerTrust.Kind.Trusted) {
+ 			this._logService.trace(`MCP server ${definition.id} is trusted, no trust prompt needed`);
+ 			return true;

--- a/patches/common/fix-remote-hosts-loopback-check.diff
+++ b/patches/common/fix-remote-hosts-loopback-check.diff
@@ -1,0 +1,97 @@
+Backport remote hosts loopback check from upstream Code-OSS.
+Prompts user before connecting to non-loopback remote host:port authorities
+to prevent crafted workspaces from silently connecting to attacker-controlled
+servers.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e
+@finding-id: GHSA-remote-hosts-loopback
+Index: b/src/vs/platform/remote/common/remoteHosts.ts
+===================================================================
+--- a/src/vs/platform/remote/common/remoteHosts.ts
++++ b/src/vs/platform/remote/common/remoteHosts.ts
+@@ -63,3 +63,20 @@ function parseAuthority(authority: strin
+ 	// doesn't contain a port
+ 	return { host: authority, port: undefined };
+ }
++
++const loopbackHosts = new Set([
++	'localhost',
++	'127.0.0.1',
++	'::1',
++	'[::1]',
++	'0000:0000:0000:0000:0000:0000:0000:0001',
++	'[0000:0000:0000:0000:0000:0000:0000:0001]'
++]);
++
++/**
++ * Returns whether the given host (as found in a direct `<host>:<port>` remote
++ * authority) refers to the local loopback interface.
++ */
++export function isLoopbackHost(host: string): boolean {
++	return loopbackHosts.has(host.toLowerCase());
++}
+Index: b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+===================================================================
+--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
++++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+@@ -118,7 +118,7 @@ export abstract class AbstractExtensionS
+ 		@IRemoteExtensionsScannerService protected readonly _remoteExtensionsScannerService: IRemoteExtensionsScannerService,
+ 		@ILifecycleService private readonly _lifecycleService: ILifecycleService,
+ 		@IRemoteAuthorityResolverService protected readonly _remoteAuthorityResolverService: IRemoteAuthorityResolverService,
+-		@IDialogService private readonly _dialogService: IDialogService,
++		@IDialogService protected readonly _dialogService: IDialogService,
+ 	) {
+ 		super();
+ 
+Index: b/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
+===================================================================
+--- a/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
++++ b/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
+@@ -29,9 +29,9 @@ import { IOpenerService } from '../../..
+ import { IProductService } from '../../../../platform/product/common/productService.js';
+ import { PersistentConnectionEventType } from '../../../../platform/remote/common/remoteAgentConnection.js';
+ import { IRemoteAgentEnvironment } from '../../../../platform/remote/common/remoteAgentEnvironment.js';
+-import { IRemoteAuthorityResolverService, RemoteAuthorityResolverError, RemoteConnectionType, ResolverResult, getRemoteAuthorityPrefix } from '../../../../platform/remote/common/remoteAuthorityResolver.js';
++import { IRemoteAuthorityResolverService, RemoteAuthorityResolverError, RemoteAuthorityResolverErrorCode, RemoteConnectionType, ResolverResult, getRemoteAuthorityPrefix } from '../../../../platform/remote/common/remoteAuthorityResolver.js';
+ import { IRemoteExtensionsScannerService } from '../../../../platform/remote/common/remoteExtensionsScanner.js';
+-import { getRemoteName, parseAuthorityWithPort } from '../../../../platform/remote/common/remoteHosts.js';
++import { getRemoteName, isLoopbackHost, parseAuthorityWithPort } from '../../../../platform/remote/common/remoteHosts.js';
+ import { updateProxyConfigurationsScope } from '../../../../platform/request/common/request.js';
+ import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+ import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+@@ -275,6 +275,11 @@ export class NativeExtensionService exte
+ 		if (authorityPlusIndex === -1) {
+ 			// This authority does not need to be resolved, simply parse the port number
+ 			const { host, port } = parseAuthorityWithPort(remoteAuthority);
++
++			if (!isLoopbackHost(host)) {
++				await this._confirmDirectRemoteConnection(host, port);
++			}
++
+ 			return {
+ 				authority: {
+ 					authority: remoteAuthority,
+@@ -291,6 +296,22 @@ export class NativeExtensionService exte
+ 		return this._resolveAuthorityOnExtensionHosts(ExtensionHostKind.LocalProcess, remoteAuthority);
+ 	}
+ 
++	private async _confirmDirectRemoteConnection(host: string, port: number): Promise<void> {
++		const { confirmed } = await this._dialogService.confirm({
++			type: Severity.Warning,
++			message: nls.localize('remoteConnectionConfirm', "Allow connecting to the remote server '{0}:{1}'?", host, port),
++			detail: nls.localize('remoteConnectionConfirmDetail', "Code is about to connect to '{0}:{1}' to host a remote extension host. Only continue if you trust this server, as it will be able to run code and access files on your behalf.", host, port),
++			primaryButton: nls.localize('remoteConnectionConfirmButton', "Connect")
++		});
++
++		if (!confirmed) {
++			throw new RemoteAuthorityResolverError(
++				nls.localize('remoteConnectionRejected', "Connection to '{0}:{1}' was not allowed.", host, port),
++				RemoteAuthorityResolverErrorCode.NotAvailable
++			);
++		}
++	}
++
+ 	private async _getCanonicalURI(remoteAuthority: string, uri: URI): Promise<URI> {
+ 
+ 		const authorityPlusIndex = remoteAuthority.indexOf('+');

--- a/patches/common/fix-snippets-path-traversal.diff
+++ b/patches/common/fix-snippets-path-traversal.diff
@@ -1,0 +1,92 @@
+Backport profile snippets path traversal fix from upstream Code-OSS.
+Validates that snippet keys from imported profiles do not escape the
+snippets folder via path traversal segments.
+Remove when Code-OSS is updated to >= 1.123.1.
+
+@backported: https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201
+@finding-id: GHSA-snippets-path-traversal
+Index: b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+===================================================================
+--- a/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
++++ b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+@@ -6,10 +6,12 @@
+ import { VSBuffer } from '../../../../base/common/buffer.js';
+ import { IStringDictionary } from '../../../../base/common/collections.js';
+ import { ResourceSet } from '../../../../base/common/map.js';
++import { IExtUri } from '../../../../base/common/resources.js';
+ import { URI } from '../../../../base/common/uri.js';
+ import { localize } from '../../../../nls.js';
+ import { FileOperationError, FileOperationResult, IFileService, IFileStat } from '../../../../platform/files/common/files.js';
+ import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
++import { ILogService } from '../../../../platform/log/common/log.js';
+ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+ import { IUserDataProfile, ProfileResourceType } from '../../../../platform/userDataProfile/common/userDataProfile.js';
+ import { API_OPEN_EDITOR_COMMAND_ID } from '../../../browser/parts/editor/editorCommands.js';
+@@ -20,19 +22,32 @@ interface ISnippetsContent {
+ 	snippets: IStringDictionary<string>;
+ }
+ 
++function toSnippetResource(extUri: IExtUri, snippetsHome: URI, key: string): URI | undefined {
++	const resource = extUri.joinPath(snippetsHome, key);
++	if (!extUri.isEqualOrParent(resource, snippetsHome) || extUri.isEqual(resource, snippetsHome)) {
++		return undefined;
++	}
++	return resource;
++}
++
+ export class SnippetsResourceInitializer implements IProfileResourceInitializer {
+ 
+ 	constructor(
+ 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
+ 		@IFileService private readonly fileService: IFileService,
+ 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
++		@ILogService private readonly logService: ILogService,
+ 	) {
+ 	}
+ 
+ 	async initialize(content: string): Promise<void> {
+ 		const snippetsContent: ISnippetsContent = JSON.parse(content);
+ 		for (const key in snippetsContent.snippets) {
+-			const resource = this.uriIdentityService.extUri.joinPath(this.userDataProfileService.currentProfile.snippetsHome, key);
++			const resource = toSnippetResource(this.uriIdentityService.extUri, this.userDataProfileService.currentProfile.snippetsHome, key);
++			if (!resource) {
++				this.logService.warn(`SnippetsResourceInitializer: Ignoring snippet with key '${key}' as it escapes the snippets folder.`);
++				continue;
++			}
+ 			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
+ 		}
+ 	}
+@@ -43,6 +58,7 @@ export class SnippetsResource implements
+ 	constructor(
+ 		@IFileService private readonly fileService: IFileService,
+ 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
++		@ILogService private readonly logService: ILogService,
+ 	) {
+ 	}
+ 
+@@ -54,7 +70,11 @@ export class SnippetsResource implements
+ 	async apply(content: string, profile: IUserDataProfile): Promise<void> {
+ 		const snippetsContent: ISnippetsContent = JSON.parse(content);
+ 		for (const key in snippetsContent.snippets) {
+-			const resource = this.uriIdentityService.extUri.joinPath(profile.snippetsHome, key);
++			const resource = toSnippetResource(this.uriIdentityService.extUri, profile.snippetsHome, key);
++			if (!resource) {
++				this.logService.warn(`SnippetsResource: Ignoring snippet with key '${key}' as it escapes the snippets folder.`);
++				continue;
++			}
+ 			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
+ 		}
+ 	}
+Index: b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+===================================================================
+--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
++++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+@@ -85,7 +85,7 @@ export class UserDataProfileInitializer
+ 				promises.push(this.initialize(new McpResourceInitializer(this.userDataProfileService, this.fileService, this.logService), profileTemplate.mcp, ProfileResourceType.Mcp));
+ 			}
+ 			if (profileTemplate?.snippets) {
+-				promises.push(this.initialize(new SnippetsResourceInitializer(this.userDataProfileService, this.fileService, this.uriIdentityService), profileTemplate.snippets, ProfileResourceType.Snippets));
++				promises.push(this.initialize(new SnippetsResourceInitializer(this.userDataProfileService, this.fileService, this.uriIdentityService, this.logService), profileTemplate.snippets, ProfileResourceType.Snippets));
+ 			}
+ 			promises.push(this.initializeInstalledExtensions(instantiationService));
+ 			await Promises.settled(promises);

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -27,6 +27,7 @@ web-server/local-storage.diff
 web-server/base-path.diff
 web-server/webview.diff
 common/finding-override-ip-address.diff
+common/finding-override-shell-quote.diff
 common/fix-mcp-server-editor-disclosure.diff
 web-server/marketplace.diff
 web-server/integration.diff
@@ -54,3 +55,8 @@ sagemaker/sanitize-terminal-sendtext-paths.diff
 sagemaker/override-picomatch-post-startup-notifications.diff
 sagemaker/remove-delay-shutdown-endpoint.diff
 sagemaker/fix-web-extension-resource-host-validation.diff
+common/fix-github-credential-provider-host-match.diff
+common/fix-extpath-is-equal-or-parent.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback-check.diff
+common/fix-mcp-workspace-trust.diff

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -23,7 +23,13 @@ common/override-picomatch.diff
 common/override-follow-redirects.diff
 common/override-uuid-ghsa-w5hq.diff
 common/finding-override-ip-address.diff
+common/finding-override-shell-quote.diff
 common/fix-mcp-server-editor-disclosure.diff
+common/fix-github-credential-provider-host-match.diff
+common/fix-extpath-is-equal-or-parent.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback-check.diff
+common/fix-mcp-workspace-trust.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -23,7 +23,13 @@ common/override-picomatch.diff
 common/override-follow-redirects.diff
 common/override-uuid-ghsa-w5hq.diff
 common/finding-override-ip-address.diff
+common/finding-override-shell-quote.diff
 common/fix-mcp-server-editor-disclosure.diff
+common/fix-github-credential-provider-host-match.diff
+common/fix-extpath-is-equal-or-parent.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback-check.diff
+common/fix-mcp-workspace-trust.diff
 web-embedded/readd-workbench.diff
 web-embedded/suppress-known-errors-build-integration.diff
 web-embedded/disable-built-in-walkthroughs-from-c.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -23,7 +23,13 @@ common/override-picomatch.diff
 common/override-follow-redirects.diff
 common/override-uuid-ghsa-w5hq.diff
 common/finding-override-ip-address.diff
+common/finding-override-shell-quote.diff
 common/fix-mcp-server-editor-disclosure.diff
+common/fix-github-credential-provider-host-match.diff
+common/fix-extpath-is-equal-or-parent.diff
+common/fix-snippets-path-traversal.diff
+common/fix-remote-hosts-loopback-check.diff
+common/fix-mcp-workspace-trust.diff
 web-server/suppress-known-errors-build-integration.diff
 web-server/local-storage.diff
 web-server/base-path.diff


### PR DESCRIPTION
## Issue

Security scan findings from nightly workflow.

## Description of Changes

- Override `shell-quote` to `^1.8.4` (transitive dependency, all targets)
- Backport upstream Code-OSS security fixes via quilt patches:
  - Credential provider strict host matching
  - Profile snippets path traversal protection
  - Remote hosts loopback validation helper
  - (1.0/1.1 only) Terminal auto-replies restriction, MCP workspace trust, extpath improvements

## Testing

- `prepare-src.sh` passes for all targets (patches apply cleanly)
- Lockfile validation confirms `shell-quote@1.8.4` resolved in all package-lock-overrides
- Dev build verified on 1.1 and 1.2 branches (identical source to 1.0 and main respectively)

## Screenshots/Videos

N/A

## Additional Notes

Sibling PRs created for all active branches (main, 1.0, 1.1, 1.2).

## Backporting

Applied to all active branches simultaneously.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
