### PR TITLE
chore: patch security findings (shell-quote override + GHSA backports)

### DIFF
--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -49,7 +49,6 @@
         "@xterm/headless": "^6.1.0-beta.197",
         "@xterm/xterm": "^6.1.0-beta.197",
         "chrome-remote-interface": "^0.33.0",
-        "http-proxy": "^1.18.1",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
         "jschardet": "3.1.4",
@@ -79,7 +78,6 @@
         "@types/debug": "^4.1.5",
         "@types/eslint": "^9.6.1",
         "@types/gulp-svgmin": "^1.2.1",
-        "@types/http-proxy": "^1.17.15",
         "@types/http-proxy-agent": "^2.0.1",
         "@types/kerberos": "^1.1.2",
         "@types/minimist": "^1.2.1",
@@ -2665,16 +2663,6 @@
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/http-proxy": {
-      "version": "1.17.17",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
-      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/http-proxy-agent": {
       "version": "2.0.1",
@@ -7797,12 +7785,6 @@
         "through": "~2.3.1"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -11169,20 +11151,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -15949,7 +15917,8 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -16635,9 +16604,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/sagemaker.series/remote/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/remote/package-lock.json
@@ -36,7 +36,6 @@
         "@xterm/headless": "^6.1.0-beta.197",
         "@xterm/xterm": "^6.1.0-beta.197",
         "cookie": "^0.7.0",
-        "http-proxy": "^1.18.1",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
         "jschardet": "3.1.4",
@@ -962,12 +961,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
-    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -980,26 +973,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/fs-extra": {
       "version": "11.2.0",
@@ -1018,20 +991,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.0",
@@ -1243,12 +1202,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -1256,9 +1209,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -16604,9 +16604,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -16604,9 +16604,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -16635,9 +16635,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-server.series/remote/package-lock.json
+++ b/package-lock-overrides/web-server.series/remote/package-lock.json
@@ -1256,9 +1256,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/patches/backported-patches.json
+++ b/patches/backported-patches.json
@@ -1,1 +1,52 @@
-[]
+[
+  {
+    "finding_id": "CVE-2026-47284",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/ghsa-credential-provider-host-match.diff",
+    "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
+  },
+  {
+    "finding_id": "GHSA-qcxw-jfff-cxpc",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/ghsa-credential-provider-host-match.diff",
+    "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
+  },
+  {
+    "finding_id": "CVE-2026-47287",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/ghsa-snippets-path-traversal.diff",
+    "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+  },
+  {
+    "finding_id": "GHSA-hgwg-xqr5-q87f",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/ghsa-snippets-path-traversal.diff",
+    "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+  },
+  {
+    "finding_id": "CVE-2026-47281",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/ghsa-remote-hosts-loopback.diff",
+    "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
+  },
+  {
+    "finding_id": "GHSA-5j3g-c7qg-xfvx",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "patches/common/ghsa-remote-hosts-loopback.diff",
+    "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
+  },
+  {
+    "finding_id": "CVE-2026-45482",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "N/A",
+    "link": "https://github.com/advisories/GHSA-c82g-9gj4-hxp2",
+    "note": "GitHub Copilot path traversal - Copilot not present in Code Editor"
+  },
+  {
+    "finding_id": "GHSA-c82g-9gj4-hxp2",
+    "affected_versions": "< 1.123.1",
+    "patch_path": "N/A",
+    "link": "https://github.com/advisories/GHSA-c82g-9gj4-hxp2",
+    "note": "GitHub Copilot path traversal - Copilot not present in Code Editor"
+  }
+]

--- a/patches/common/finding-override-shell-quote.diff
+++ b/patches/common/finding-override-shell-quote.diff
@@ -1,0 +1,32 @@
+Override shell-quote to ^1.8.4.
+Regenerate: npx ts-node build-tools/apply-finding-overrides/apply-finding-overrides.ts apply --patch common/finding-override-shell-quote.diff --override global:shell-quote=^1.8.4 --override remote/package.json@global:shell-quote=^1.8.4
+Remove when upstream Code-OSS updates shell-quote to >= 1.8.4.
+
+@generated
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-shell-quote.diff --override 'global:shell-quote=^1.8.4' --override 'remote/package.json@global:shell-quote=^1.8.4'
+@override-package: shell-quote@^1.8.4
+
+Index: b/package.json
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -246,6 +246,7 @@
+     "yaserver": "^0.4.0"
+   },
+   "overrides": {
++    "shell-quote": "^1.8.4",
+     "postcss": "^8.4.31",
+     "node-gyp-build": "4.8.1",
+     "serialize-javascript": "^7.0.3",
+Index: b/remote/package.json
+===================================================================
+--- a/remote/package.json
++++ b/remote/package.json
+@@ -48,6 +48,7 @@
+     "yazl": "^2.4.3"
+   },
+   "overrides": {
++    "shell-quote": "^1.8.4",
+     "node-gyp-build": "4.8.1",
+     "ssh2": {
+       "cpu-features": "0.0.0"

--- a/patches/common/ghsa-credential-provider-host-match.diff
+++ b/patches/common/ghsa-credential-provider-host-match.diff
@@ -1,0 +1,22 @@
+From: Ladislau Szomoru <lszomoru@microsoft.com>
+Subject: GitHub - improve host parsing
+Origin: upstream, https://github.com/microsoft/vscode/commit/4b6e2467
+Bug: GHSA credential provider regex host match
+
+Change GitHub credential provider from regex-based host matching to
+strict hostname equality check to prevent credential leakage to
+attacker-controlled domains matching the pattern (e.g. notgithub.com).
+Index: b/extensions/github/src/credentialProvider.ts
+===================================================================
+--- a/extensions/github/src/credentialProvider.ts
++++ b/extensions/github/src/credentialProvider.ts
+@@ -12,7 +12,8 @@ const EmptyDisposable: Disposable = { di
+ class GitHubCredentialProvider implements CredentialsProvider {
+ 
+ 	async getCredentials(host: Uri): Promise<Credentials | undefined> {
+-		if (!/github\.com/i.test(host.authority)) {
++		const hostname = host.authority.replace(/:\d+$/, '').toLowerCase();
++		if (hostname !== 'github.com') {
+ 			return;
+ 		}
+ 

--- a/patches/common/ghsa-remote-hosts-loopback.diff
+++ b/patches/common/ghsa-remote-hosts-loopback.diff
@@ -1,0 +1,34 @@
+From: Alexandru Dima <alexdima@microsoft.com>
+Subject: Add isLoopbackHost helper for remote authority validation
+Origin: upstream, https://github.com/microsoft/vscode/commit/9505d0fc
+Bug: GHSA remote hosts loopback check
+
+Add isLoopbackHost function to validate whether a direct host:port remote
+authority targets the local loopback interface. This enables prompting users
+before connecting to non-loopback remote hosts that could originate from
+untrusted workspace files.
+Index: b/src/vs/platform/remote/common/remoteHosts.ts
+===================================================================
+--- a/src/vs/platform/remote/common/remoteHosts.ts
++++ b/src/vs/platform/remote/common/remoteHosts.ts
+@@ -87,3 +87,20 @@ function parseAuthority(authority: strin
+ 	// doesn't contain a port
+ 	return { host: authority, port: undefined };
+ }
++
++const loopbackHosts = new Set([
++	'localhost',
++	'127.0.0.1',
++	'::1',
++	'[::1]',
++	'0000:0000:0000:0000:0000:0000:0000:0001',
++	'[0000:0000:0000:0000:0000:0000:0000:0001]'
++]);
++
++/**
++ * Returns whether the given host (as found in a direct `<host>:<port>` remote
++ * authority) refers to the local loopback interface.
++ */
++export function isLoopbackHost(host: string): boolean {
++	return loopbackHosts.has(host.toLowerCase());
++}

--- a/patches/common/ghsa-snippets-path-traversal.diff
+++ b/patches/common/ghsa-snippets-path-traversal.diff
@@ -1,0 +1,93 @@
+From: Sandeep Somavarapu <sasomava@microsoft.com>
+Subject: path traversal fix
+Origin: upstream, https://github.com/microsoft/vscode/commit/9b31ff89
+Bug: GHSA profile snippets path traversal
+
+Add path traversal protection to snippet import. Validates that resolved
+snippet resource URIs remain within the snippetsHome directory, preventing
+an attacker-crafted profile from writing files outside the profile folder.
+Index: b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+===================================================================
+--- a/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
++++ b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+@@ -6,10 +6,12 @@
+ import { VSBuffer } from '../../../../base/common/buffer.js';
+ import { IStringDictionary } from '../../../../base/common/collections.js';
+ import { ResourceSet } from '../../../../base/common/map.js';
++import { IExtUri } from '../../../../base/common/resources.js';
+ import { URI } from '../../../../base/common/uri.js';
+ import { localize } from '../../../../nls.js';
+ import { FileOperationError, FileOperationResult, IFileService, IFileStat } from '../../../../platform/files/common/files.js';
+ import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
++import { ILogService } from '../../../../platform/log/common/log.js';
+ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+ import { IUserDataProfile, ProfileResourceType } from '../../../../platform/userDataProfile/common/userDataProfile.js';
+ import { API_OPEN_EDITOR_COMMAND_ID } from '../../../browser/parts/editor/editorCommands.js';
+@@ -20,19 +22,32 @@ interface ISnippetsContent {
+ 	snippets: IStringDictionary<string>;
+ }
+ 
++function toSnippetResource(extUri: IExtUri, snippetsHome: URI, key: string): URI | undefined {
++	const resource = extUri.joinPath(snippetsHome, key);
++	if (!extUri.isEqualOrParent(resource, snippetsHome) || extUri.isEqual(resource, snippetsHome)) {
++		return undefined;
++	}
++	return resource;
++}
++
+ export class SnippetsResourceInitializer implements IProfileResourceInitializer {
+ 
+ 	constructor(
+ 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
+ 		@IFileService private readonly fileService: IFileService,
+ 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
++		@ILogService private readonly logService: ILogService,
+ 	) {
+ 	}
+ 
+ 	async initialize(content: string): Promise<void> {
+ 		const snippetsContent: ISnippetsContent = JSON.parse(content);
+ 		for (const key in snippetsContent.snippets) {
+-			const resource = this.uriIdentityService.extUri.joinPath(this.userDataProfileService.currentProfile.snippetsHome, key);
++			const resource = toSnippetResource(this.uriIdentityService.extUri, this.userDataProfileService.currentProfile.snippetsHome, key);
++			if (!resource) {
++				this.logService.warn(`SnippetsResourceInitializer: Ignoring snippet with key '${key}' as it escapes the snippets folder.`);
++				continue;
++			}
+ 			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
+ 		}
+ 	}
+@@ -43,6 +58,7 @@ export class SnippetsResource implements
+ 	constructor(
+ 		@IFileService private readonly fileService: IFileService,
+ 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
++		@ILogService private readonly logService: ILogService,
+ 	) {
+ 	}
+ 
+@@ -54,7 +70,11 @@ export class SnippetsResource implements
+ 	async apply(content: string, profile: IUserDataProfile): Promise<void> {
+ 		const snippetsContent: ISnippetsContent = JSON.parse(content);
+ 		for (const key in snippetsContent.snippets) {
+-			const resource = this.uriIdentityService.extUri.joinPath(profile.snippetsHome, key);
++			const resource = toSnippetResource(this.uriIdentityService.extUri, profile.snippetsHome, key);
++			if (!resource) {
++				this.logService.warn(`SnippetsResource: Ignoring snippet with key '${key}' as it escapes the snippets folder.`);
++				continue;
++			}
+ 			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
+ 		}
+ 	}
+Index: b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+===================================================================
+--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
++++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+@@ -85,7 +85,7 @@ export class UserDataProfileInitializer
+ 				promises.push(this.initialize(new McpResourceInitializer(this.userDataProfileService, this.fileService, this.logService), profileTemplate.mcp, ProfileResourceType.Mcp));
+ 			}
+ 			if (profileTemplate?.snippets) {
+-				promises.push(this.initialize(new SnippetsResourceInitializer(this.userDataProfileService, this.fileService, this.uriIdentityService), profileTemplate.snippets, ProfileResourceType.Snippets));
++				promises.push(this.initialize(new SnippetsResourceInitializer(this.userDataProfileService, this.fileService, this.uriIdentityService, this.logService), profileTemplate.snippets, ProfileResourceType.Snippets));
+ 			}
+ 			promises.push(this.initializeInstalledExtensions(instantiationService));
+ 			await Promises.settled(promises);

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -64,3 +64,7 @@ common/finding-override-axios.diff
 common/finding-override-ws.diff
 common/finding-override-anthropic-sdk.diff
 common/finding-override-github-copilot.diff
+common/finding-override-shell-quote.diff
+common/ghsa-credential-provider-host-match.diff
+common/ghsa-snippets-path-traversal.diff
+common/ghsa-remote-hosts-loopback.diff

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -61,3 +61,7 @@ web-embedded/remove-new-window-actions-and-profile-workspace-section.diff
 web-embedded/only-allow-trusted-origins-in-webviews.diff
 web-embedded/disable-accounts-and-profiles.diff
 web-embedded/disable-file-actions.diff
+common/finding-override-shell-quote.diff
+common/ghsa-credential-provider-host-match.diff
+common/ghsa-snippets-path-traversal.diff
+common/ghsa-remote-hosts-loopback.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -64,3 +64,7 @@ web-embedded/only-allow-trusted-origins-in-webviews.diff
 web-embedded/enable-ts-features.diff
 web-embedded/disable-accounts-and-profiles.diff
 web-embedded/disable-file-actions.diff
+common/finding-override-shell-quote.diff
+common/ghsa-credential-provider-host-match.diff
+common/ghsa-snippets-path-traversal.diff
+common/ghsa-remote-hosts-loopback.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -43,3 +43,7 @@ web-server/embedding-events.diff
 web-server/proxy-uri.diff
 web-server/display-language.diff
 web-server/signature-verification.diff
+common/finding-override-shell-quote.diff
+common/ghsa-credential-provider-host-match.diff
+common/ghsa-snippets-path-traversal.diff
+common/ghsa-remote-hosts-loopback.diff


### PR DESCRIPTION
## Issue

Security scan findings from nightly workflow.

## Description of Changes

- Override `shell-quote` to `^1.8.4` (transitive dependency, all targets)
- Backport upstream Code-OSS security fixes via quilt patches:
  - Credential provider strict host matching
  - Profile snippets path traversal protection
  - Remote hosts loopback validation helper
  - (1.0/1.1 only) Terminal auto-replies restriction, MCP workspace trust, extpath improvements

## Testing

- `prepare-src.sh` passes for all targets (patches apply cleanly)
- Lockfile validation confirms `shell-quote@1.8.4` resolved in all package-lock-overrides
- Dev build verified on 1.1 and 1.2 branches (identical source to 1.0 and main respectively)

## Screenshots/Videos

N/A

## Additional Notes

Sibling PRs created for all active branches (main, 1.0, 1.1, 1.2).

## Backporting

Applied to all active branches simultaneously.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
