### PR TITLE
chore: add missing GHSA/CVE IDs to backported-patches.json

### DIFF
--- a/patches/backported-patches.json
+++ b/patches/backported-patches.json
@@ -44,10 +44,40 @@
         "note": "Copilot extension not present in Code-OSS 1.108.2"
     },
     {
-        "finding_id": "GHSA-credential-provider-host-match",
-        "affected_versions": "<1.123.1",
+        "finding_id": "CVE-2026-47284",
+        "affected_versions": "< 1.123.1",
         "patch_path": "common/fix-github-credential-provider-host-match.diff",
         "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
+    },
+    {
+        "finding_id": "GHSA-qcxw-jfff-cxpc",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "common/fix-github-credential-provider-host-match.diff",
+        "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
+    },
+    {
+        "finding_id": "CVE-2026-47287",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "common/fix-snippets-path-traversal.diff",
+        "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+    },
+    {
+        "finding_id": "GHSA-hgwg-xqr5-q87f",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "common/fix-snippets-path-traversal.diff",
+        "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+    },
+    {
+        "finding_id": "CVE-2026-47281",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "common/fix-remote-hosts-loopback-check.diff",
+        "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
+    },
+    {
+        "finding_id": "GHSA-5j3g-c7qg-xfvx",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "common/fix-remote-hosts-loopback-check.diff",
+        "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
     },
     {
         "finding_id": "GHSA-extpath-is-equal-or-parent",
@@ -56,15 +86,17 @@
         "link": "https://github.com/microsoft/vscode/commit/0f1ba1ea103757f3023cc1f9c3eb7327c3ec4b02"
     },
     {
-        "finding_id": "GHSA-snippets-path-traversal",
-        "affected_versions": "<1.123.1",
-        "patch_path": "common/fix-snippets-path-traversal.diff",
-        "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+        "finding_id": "CVE-2026-45482",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/advisories/GHSA-c82g-9gj4-hxp2",
+        "note": "GitHub Copilot path traversal - Copilot not present in Code Editor"
     },
     {
-        "finding_id": "GHSA-remote-hosts-loopback",
-        "affected_versions": "<1.123.1",
-        "patch_path": "common/fix-remote-hosts-loopback-check.diff",
-        "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
+        "finding_id": "GHSA-c82g-9gj4-hxp2",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/advisories/GHSA-c82g-9gj4-hxp2",
+        "note": "GitHub Copilot path traversal - Copilot not present in Code Editor"
     }
 ]


### PR DESCRIPTION
## Issue

Nightly Security Scan reports 3 concerning GHSA advisories on branch 1.1 because `backported-patches.json` uses custom descriptive IDs instead of the actual GHSA/CVE identifiers the scan checks.

## Description of Changes

Updates `patches/backported-patches.json` to add proper GHSA IDs (GHSA-qcxw-jfff-cxpc, GHSA-hgwg-xqr5-q87f, GHSA-5j3g-c7qg-xfvx) and CVE IDs (CVE-2026-47284, CVE-2026-47287, CVE-2026-47281) for existing backport patches. Also adds N/A entries for CVE-2026-45482/GHSA-c82g-9gj4-hxp2 (Copilot path traversal — component not present in Code Editor).

No patches added or modified. No lockfile changes.

## Testing

- Verified the scan script reads `.[].finding_id` from the JSON file
- Confirmed all GHSA IDs flagged by the scan now have corresponding entries

## Screenshots/Videos
N/A

## Additional Notes

Sibling PRs: #240 (main), #243 (1.2), and a matching PR on 1.0.

## Backporting

This is a metadata-only fix applied independently per branch.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.