### PR TITLE
chore: add missing GHSA/CVE IDs to backported-patches.json

### DIFF
--- a/patches/backported-patches.json
+++ b/patches/backported-patches.json
@@ -1,26 +1,98 @@
 [
-  {
-    "finding_id": "CVE-2026-21523",
-    "affected_versions": "< 1.109.1",
-    "patch_path": "patches/common/fix-terminal-autoreplies.diff",
-    "link": "https://github.com/microsoft/vscode/commit/6534f6ba"
-  },
-  {
-    "finding_id": "CVE-2026-47284",
-    "affected_versions": "< 1.123.1",
-    "patch_path": "patches/common/fix-github-credential-provider-host-check.diff",
-    "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
-  },
-  {
-    "finding_id": "CVE-2026-47287",
-    "affected_versions": "< 1.123.1",
-    "patch_path": "patches/common/fix-snippets-path-traversal.diff",
-    "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
-  },
-  {
-    "finding_id": "CVE-2026-47281",
-    "affected_versions": "< 1.123.1",
-    "patch_path": "patches/common/fix-remote-hosts-loopback-check.diff",
-    "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
-  }
+    {
+        "finding_id": "CVE-2026-21523",
+        "affected_versions": "< 1.109.1",
+        "patch_path": "patches/common/fix-terminal-autoreplies.diff",
+        "link": "https://github.com/microsoft/vscode/commit/6534f6ba"
+    },
+    {
+        "finding_id": "GHSA-3pwg-f3hj-wp8p",
+        "affected_versions": "< 1.109.1",
+        "patch_path": "patches/common/fix-terminal-autoreplies.diff",
+        "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-3pwg-f3hj-wp8p"
+    },
+    {
+        "finding_id": "CVE-2026-47284",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "patches/common/fix-github-credential-provider-host-check.diff",
+        "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
+    },
+    {
+        "finding_id": "GHSA-qcxw-jfff-cxpc",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "patches/common/fix-github-credential-provider-host-check.diff",
+        "link": "https://github.com/microsoft/vscode/commit/4b6e2467dbd828018d602f73cc25d1b11f699d2c"
+    },
+    {
+        "finding_id": "CVE-2026-47287",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "patches/common/fix-snippets-path-traversal.diff",
+        "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+    },
+    {
+        "finding_id": "GHSA-hgwg-xqr5-q87f",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "patches/common/fix-snippets-path-traversal.diff",
+        "link": "https://github.com/microsoft/vscode/commit/9b31ff896671125cbfc65f33731c4a99660d6201"
+    },
+    {
+        "finding_id": "CVE-2026-47281",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "patches/common/fix-remote-hosts-loopback-check.diff",
+        "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
+    },
+    {
+        "finding_id": "GHSA-5j3g-c7qg-xfvx",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "patches/common/fix-remote-hosts-loopback-check.diff",
+        "link": "https://github.com/microsoft/vscode/commit/9505d0fca49eadb707c450d18dcb41a46b720a9e"
+    },
+    {
+        "finding_id": "GHSA-extpath-is-equal-or-parent",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "patches/common/fix-extpath-is-equal-or-parent.diff",
+        "link": "https://github.com/microsoft/vscode/commit/0f1ba1ea103757f3023cc1f9c3eb7327c3ec4b02"
+    },
+    {
+        "finding_id": "CVE-2026-45482",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/advisories/GHSA-c82g-9gj4-hxp2",
+        "note": "GitHub Copilot path traversal - Copilot not present in Code Editor"
+    },
+    {
+        "finding_id": "GHSA-c82g-9gj4-hxp2",
+        "affected_versions": "< 1.123.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/advisories/GHSA-c82g-9gj4-hxp2",
+        "note": "GitHub Copilot path traversal - Copilot not present in Code Editor"
+    },
+    {
+        "finding_id": "CVE-2026-41613",
+        "affected_versions": "< 1.119.1",
+        "patch_path": "N/A",
+        "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-41613",
+        "note": "MCP server editor disclosure - vulnerable UI feature not present in Code-OSS 1.101.2"
+    },
+    {
+        "finding_id": "GHSA-9f6c-63gp-pwpf",
+        "affected_versions": "< 1.119.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-9f6c-63gp-pwpf",
+        "note": "MCP server editor disclosure - vulnerable UI feature not present in Code-OSS 1.101.2"
+    },
+    {
+        "finding_id": "CVE-2026-41109",
+        "affected_versions": "< 1.119.1",
+        "patch_path": "N/A",
+        "link": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-41109",
+        "note": "Copilot extension not present in Code-OSS 1.101.2"
+    },
+    {
+        "finding_id": "GHSA-rg3f-8xq5-hwh6",
+        "affected_versions": "< 1.119.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/microsoft/vscode/security/advisories/GHSA-rg3f-8xq5-hwh6",
+        "note": "Copilot extension not present in Code-OSS 1.101.2"
+    }
 ]


### PR DESCRIPTION
## Issue

Nightly Security Scan reports 2 concerning GHSA advisories on branch 1.0 because `backported-patches.json` is missing entries for several identifiers the scan checks.

## Description of Changes

Updates `patches/backported-patches.json` to:
- Add GHSA IDs (GHSA-3pwg-f3hj-wp8p, GHSA-qcxw-jfff-cxpc, GHSA-hgwg-xqr5-q87f, GHSA-5j3g-c7qg-xfvx) for existing backport patches
- Add entry for existing `fix-extpath-is-equal-or-parent.diff` patch (was missing from JSON)
- Add N/A entries for CVE-2026-45482/GHSA-c82g-9gj4-hxp2 (Copilot — not present)
- Add N/A entries for CVE-2026-41613/GHSA-9f6c-63gp-pwpf (MCP server editor disclosure — vulnerable UI feature not present in Code-OSS 1.101.2)
- Add N/A entries for CVE-2026-41109/GHSA-rg3f-8xq5-hwh6 (Copilot — not present)

No patches added or modified. No lockfile changes.

## Testing

- Verified `mcpServerEditor.ts` on 1.0 has no env var display code (684 lines, no `config.env` references)
- Confirmed all GHSA IDs flagged by the scan now have corresponding entries

## Screenshots/Videos
N/A

## Additional Notes

Sibling PRs: #240 (main), #243 (1.2), #244 (1.1).

## Backporting

This is a metadata-only fix applied independently per branch.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.