### PR TITLE
[1.1] Fix security scan: override undici and ws

### DIFF
--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -49,7 +49,7 @@
         "node-pty": "^1.1.0-beta43",
         "open": "^10.1.2",
         "tas-client": "0.3.1",
-        "undici": "^7.24.0",
+        "undici": "^7.28.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -148,7 +148,7 @@
         "source-map": "0.6.1",
         "source-map-support": "^0.3.2",
         "style-loader": "^3.3.2",
-        "tar": "^7.5.10",
+        "tar": "^7.5.16",
         "ts-loader": "^9.5.1",
         "tsec": "0.2.7",
         "tslib": "^2.6.3",
@@ -4786,26 +4786,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-    },
-    "node_modules/chrome-remote-interface/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.2",
@@ -15412,9 +15392,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -16202,9 +16182,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -17118,6 +17098,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/package-lock-overrides/sagemaker.series/remote/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/remote/package-lock.json
@@ -40,7 +40,7 @@
         "native-watchdog": "^1.4.1",
         "node-pty": "^1.1.0-beta43",
         "tas-client": "0.3.1",
-        "undici": "^7.24.0",
+        "undici": "^7.28.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.0",
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -48,7 +48,7 @@
         "node-pty": "^1.1.0-beta43",
         "open": "^10.1.2",
         "tas-client": "0.3.1",
-        "undici": "^7.24.0",
+        "undici": "^7.28.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -146,7 +146,7 @@
         "source-map": "0.6.1",
         "source-map-support": "^0.3.2",
         "style-loader": "^3.3.2",
-        "tar": "^7.5.10",
+        "tar": "^7.5.16",
         "ts-loader": "^9.5.1",
         "tsec": "0.2.7",
         "tslib": "^2.6.3",
@@ -4787,26 +4787,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-    },
-    "node_modules/chrome-remote-interface/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.2",
@@ -15375,9 +15355,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -16165,9 +16145,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -17081,6 +17061,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/package-lock-overrides/web-embedded.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/remote/package-lock.json
@@ -39,7 +39,7 @@
         "native-watchdog": "^1.4.1",
         "node-pty": "^1.1.0-beta43",
         "tas-client": "0.3.1",
-        "undici": "^7.24.0",
+        "undici": "^7.28.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.0",
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -49,7 +49,7 @@
         "node-pty": "^1.1.0-beta43",
         "open": "^10.1.2",
         "tas-client": "0.3.1",
-        "undici": "^7.24.0",
+        "undici": "^7.28.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -148,7 +148,7 @@
         "source-map": "0.6.1",
         "source-map-support": "^0.3.2",
         "style-loader": "^3.3.2",
-        "tar": "^7.5.10",
+        "tar": "^7.5.16",
         "ts-loader": "^9.5.1",
         "tsec": "0.2.7",
         "tslib": "^2.6.3",
@@ -4799,26 +4799,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-    },
-    "node_modules/chrome-remote-interface/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.2",
@@ -15426,9 +15406,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -16216,9 +16196,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -17132,6 +17112,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/package-lock-overrides/web-server.series/remote/package-lock.json
+++ b/package-lock-overrides/web-server.series/remote/package-lock.json
@@ -40,7 +40,7 @@
         "native-watchdog": "^1.4.1",
         "node-pty": "^1.1.0-beta43",
         "tas-client": "0.3.1",
-        "undici": "^7.24.0",
+        "undici": "^7.28.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.0",
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/patches/common/finding-override-tar.diff
+++ b/patches/common/finding-override-tar.diff
@@ -1,0 +1,29 @@
+Override tar to ^7.5.16 to fix CVE-2026-53655.
+
+@generated
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-tar.diff --override 'direct-dev:tar=^7.5.16' --override 'global:tar=^7.5.16'
+@override-package: tar@^7.5.16
+
+Index: b/package.json
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -210,7 +210,7 @@
+     "source-map": "0.6.1",
+     "source-map-support": "^0.3.2",
+     "style-loader": "^3.3.2",
+-    "tar": "^7.5.10",
++    "tar": "^7.5.16",
+     "ts-loader": "^9.5.1",
+     "tsec": "0.2.7",
+     "tslib": "^2.6.3",
+@@ -246,7 +246,8 @@
+     "ip-address": "^10.1.1",
+     "shell-quote": "^1.8.4",
+     "undici": "^7.28.0",
+-    "ws": "^7.5.11"
++    "ws": "^7.5.11",
++    "tar": "^7.5.16"
+   },
+   "repository": {
+     "type": "git",

--- a/patches/common/finding-override-undici.diff
+++ b/patches/common/finding-override-undici.diff
@@ -1,0 +1,51 @@
+Override undici to ^7.28.0 to fix CVE-2026-6734, CVE-2026-9697, CVE-2026-12151.
+
+@generated
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-undici.diff --override 'direct:undici=^7.28.0' --override 'global:undici=^7.28.0' --override 'remote/package.json@direct:undici=^7.28.0' --override 'remote/package.json@global:undici=^7.28.0'
+@override-package: undici@^7.28.0
+
+Index: b/package.json
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -111,7 +111,7 @@
+     "node-pty": "^1.1.0-beta43",
+     "open": "^10.1.2",
+     "tas-client": "0.3.1",
+-    "undici": "^7.24.0",
++    "undici": "^7.28.0",
+     "v8-inspect-profiler": "^0.1.1",
+     "vscode-oniguruma": "1.7.0",
+     "vscode-regexpp": "^3.1.0",
+@@ -244,7 +244,8 @@
+     "follow-redirects": "^1.16.0",
+     "uuid": "^14.0.0",
+     "ip-address": "^10.1.1",
+-    "shell-quote": "^1.8.4"
++    "shell-quote": "^1.8.4",
++    "undici": "^7.28.0"
+   },
+   "repository": {
+     "type": "git",
+Index: b/remote/package.json
+===================================================================
+--- a/remote/package.json
++++ b/remote/package.json
+@@ -35,7 +35,7 @@
+     "native-watchdog": "^1.4.1",
+     "node-pty": "^1.1.0-beta43",
+     "tas-client": "0.3.1",
+-    "undici": "^7.24.0",
++    "undici": "^7.28.0",
+     "vscode-oniguruma": "1.7.0",
+     "vscode-regexpp": "^3.1.0",
+     "vscode-textmate": "^9.3.0",
+@@ -48,6 +48,7 @@
+     "picomatch": "^2.3.2",
+     "follow-redirects": "^1.16.0",
+     "uuid": "^14.0.0",
+-    "ip-address": "^10.1.1"
++    "ip-address": "^10.1.1",
++    "undici": "^7.28.0"
+   }
+ }

--- a/patches/common/finding-override-ws.diff
+++ b/patches/common/finding-override-ws.diff
@@ -1,0 +1,20 @@
+Override ws to ^7.5.11 to fix CVE-2026-48779.
+
+@generated
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-ws.diff --override 'global:ws=^7.5.11'
+@override-package: ws@^7.5.11
+
+Index: b/package.json
+===================================================================
+--- a/package.json
++++ b/package.json
+@@ -245,7 +245,8 @@
+     "uuid": "^14.0.0",
+     "ip-address": "^10.1.1",
+     "shell-quote": "^1.8.4",
+-    "undici": "^7.28.0"
++    "undici": "^7.28.0",
++    "ws": "^7.5.11"
+   },
+   "repository": {
+     "type": "git",

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -61,3 +61,6 @@ common/fix-snippets-path-traversal.diff
 common/fix-remote-hosts-loopback-check.diff
 common/fix-mcp-workspace-trust.diff
 common/add-openvsx-verification-check.diff
+common/finding-override-undici.diff
+common/finding-override-ws.diff
+common/finding-override-tar.diff

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -57,3 +57,6 @@ web-embedded/fix-watch-target.diff
 web-embedded/remove-unused-recommended-extensions-action.diff
 web-embedded/remove-new-window-actions-and-profile-workspace-section.diff
 web-embedded/only-allow-trusted-origins-in-webviews.diff
+common/finding-override-undici.diff
+common/finding-override-ws.diff
+common/finding-override-tar.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -60,3 +60,6 @@ web-embedded/remove-unused-recommended-extensions-action.diff
 web-embedded/remove-new-window-actions-and-profile-workspace-section.diff
 web-embedded/only-allow-trusted-origins-in-webviews.diff
 web-embedded/enable-ts-features.diff
+common/finding-override-undici.diff
+common/finding-override-ws.diff
+common/finding-override-tar.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -41,3 +41,6 @@ web-server/embedding-events.diff
 web-server/proxy-uri.diff
 web-server/display-language.diff
 web-server/signature-verification.diff
+common/finding-override-undici.diff
+common/finding-override-ws.diff
+common/finding-override-tar.diff


### PR DESCRIPTION
Fixes HIGH CVEs on 1.1: CVE-2026-6734, CVE-2026-9697, CVE-2026-12151 (undici ^7.28.0), CVE-2026-48779 (ws ^7.5.11)