### PR TITLE
chore: Bump sagemakerCodeEditorVersion to 1.8.11

### DIFF
--- a/patches/sagemaker/display-both-versions-in-about.diff
+++ b/patches/sagemaker/display-both-versions-in-about.diff
@@ -33,7 +33,7 @@ Index: code-editor-src/product.json
  	"nameShort": "SageMaker Code Editor",
  	"nameLong": "SageMaker Code Editor",
  	"codeEditorVersion": "1.0.0",
-+	"sagemakerCodeEditorVersion":"1.8.10",
++	"sagemakerCodeEditorVersion":"1.8.11",
  	"applicationName": "code",
  	"dataFolderName": ".vscode-editor",
  	"win32MutexName": "vscodeoss",


### PR DESCRIPTION
## Issue
<!-- Please add just the issue number (e.g., D316398873) - do not paste the full link -->



## Description of Changes
<!-- Provide a clear and concise description of what changes you made and why -->
Upgrade sagemakerCodeEditorVersion from 1.8.10 to 1.8.11 in the display-both-versions-in-about patch.

## Testing
<!-- Describe how you tested this change. -->
Build verification — version string change only, no logic affected.

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate your changes or test results -->


## Additional Notes
<!-- Add any additional context, considerations, dependencies, or notes for reviewers -->
Change is limited to `/patches/sagemaker/display-both-versions-in-about.diff`

## Backporting
<!-- Consider if this change needs to be back-ported to previous active versions. -->
<!-- If the change needs to be backported, then please create separate PRs for version branches
and create a new release if required. -->

Same change applied to both 1.0 and 1.1 branches via separate PRs.
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.