### PR TITLE
fix: prefix unused context param with underscore in post-startup-noti…

### DIFF
--- a/patches/sagemaker/post-startup-notifications.diff
+++ b/patches/sagemaker/post-startup-notifications.diff
@@ -270,7 +270,7 @@ Index: code-editor-src/extensions/post-startup-notifications/src/extension.ts
 +let watcher: chokidar.FSWatcher;
 +let outputChannel: vscode.OutputChannel;
 +
-+export function activate(context: vscode.ExtensionContext) {
++export function activate(_context: vscode.ExtensionContext) {
 +    // Check if in SageMaker Unified Studio
 +    const envValue = process.env[SERVICE_NAME_ENV_KEY];
 +


### PR DESCRIPTION
…fications

## Issue
target build failed in https://github.com/aws/code-editor/actions/runs/28651915757/job/84971750002 with error 

```
Error: [09:39:56] extensions/post-startup-notifications/src/extension.ts(11,26): error TS6133: 'context' is declared but its value is never read.
Error: Process completed with exit code 1.

```



## Description of Changes
The change is to prefix unused context param with underscore to pass compiling check.


## Testing
test build passed https://github.com/aws/code-editor/actions/runs/28655470049


## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate your changes or test results -->


## Additional Notes
<!-- Add any additional context, considerations, dependencies, or notes for reviewers -->


## Backporting
<!-- Consider if this change needs to be back-ported to previous active versions. -->
<!-- If the change needs to be backported, then please create separate PRs for version branches
and create a new release if required. -->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.