### PR TITLE
fix: Set sagemakerCodeEditorVersion to 1.10.0

### DIFF
--- a/patches/sagemaker/sagemaker-product-config.diff
+++ b/patches/sagemaker/sagemaker-product-config.diff
@@ -27,5 +27,5 @@ Index: code-editor-src/product.json
  		"workbench.action.edits."
 -	]
 +	],
-+	"sagemakerCodeEditorVersion": "__SAGEMAKER_VERSION__"
++	"sagemakerCodeEditorVersion": "1.10.0"
  }


### PR DESCRIPTION
Replace `__SAGEMAKER_VERSION__` placeholder with `1.10.0` in the sagemaker-product-config patch.

This value is displayed in Help > About and gets compiled into the JS bundles at build time. The placeholder was not being substituted anywhere in the build/release pipeline, so the About dialog showed the raw placeholder string.

Previous releases (1.1.x) hardcoded the version directly in the patch. This restores that approach.