### PR TITLE
fix(proxy): Reject out-of-range port numbers in proxy request

### DIFF
--- a/patches/web-server/proxy-uri.diff
+++ b/patches/web-server/proxy-uri.diff
@@ -74,7 +74,7 @@ Index: code-editor-src/src/vs/server/node/proxyServer.ts
 ===================================================================
 --- /dev/null
 +++ code-editor-src/src/vs/server/node/proxyServer.ts
-@@ -0,0 +1,200 @@
+@@ -0,0 +1,204 @@
 +import proxyServer from "http-proxy";
 +import * as http from "http";
 +import * as net from "net";
@@ -148,6 +148,9 @@ Index: code-editor-src/src/vs/server/node/proxyServer.ts
 +			return;
 +		}
 +		const port = Number(portRaw);
++		if (port > 65535) {
++			return;
++		}
 +
 +		let base: string | undefined;
 +		if (proxyPrefix === "ports") {
@@ -159,7 +162,8 @@ Index: code-editor-src/src/vs/server/node/proxyServer.ts
 +		targetPathname = targetPathname.replace(/^[/\\][/\\]+/, "/");
 +
 +		const target = new URL((targetPathname || "/") + (sourceUrl.search ?? ""), `http://0.0.0.0:${port}`);
-+		if (target.hostname !== "0.0.0.0" || target.port !== String(port)) {
++		const effectivePort = target.port || (target.protocol === "http:" ? "80" : "443");
++		if (target.hostname !== "0.0.0.0" || effectivePort !== String(port)) {
 +			return;
 +		}
 +


### PR DESCRIPTION
## Description of Changes
Add port range validation (> 65535) before constructing the URL in
`createProxyRequest`. Without this, `new URL()` throws a `TypeError` for
invalid ports, causing an unhandled promise rejection and leaving the
client request hanging with no response.

## Testing
- Patch applies cleanly via `prepare-src.sh`

## Additional Notes
Follow-up to #272.

## Backporting
Same fix applied to all active branches.

---

By submitting this pull request, I confirm that you can use, modify, copy,
and redistribute this contribution, under the terms of your choice.