### PR TITLE
fix(sagemaker): Validate clusterId format in open-notebook extension

### DIFF
--- a/patches/sagemaker/sagemaker-open-notebook-extension.diff
+++ b/patches/sagemaker/sagemaker-open-notebook-extension.diff
@@ -128,7 +128,7 @@ Index: code-editor-src/extensions/sagemaker-open-notebook-extension/src/extensio
 ===================================================================
 --- /dev/null
 +++ code-editor-src/extensions/sagemaker-open-notebook-extension/src/extension.ts
-@@ -0,0 +1,100 @@
+@@ -0,0 +1,111 @@
 +
 +import * as vscode from 'vscode';
 +import * as https from 'https';
@@ -154,9 +154,20 @@ Index: code-editor-src/extensions/sagemaker-open-notebook-extension/src/extensio
 +    return regionRegex.test(region);
 +}
 +
++function isValidClusterId(clusterId: string): boolean {
++    // Cluster IDs/names are alphanumeric with hyphens and underscores only
++    const clusterIdRegex = /^[a-zA-Z0-9_-]+$/;
++    return clusterIdRegex.test(clusterId);
++}
++
 +async function loadAndDisplayNotebook(fileKey: string, clusterId: string, region: string) {
 +    if (!isValidRegion(region)) {
 +        vscode.window.showErrorMessage('Invalid region format. Region should only contain characters, numbers, and hyphens.');
++        return;
++    }
++
++    if (clusterId && !isValidClusterId(clusterId)) {
++        vscode.window.showErrorMessage('Invalid cluster ID format. Cluster ID should only contain letters, numbers, hyphens, and underscores.');
 +        return;
 +    }
 +    


### PR DESCRIPTION
## Issue

D316398873

## Description of Changes

Adds input validation for the `clusterId` URL parameter in the
sagemaker-open-notebook extension. Previously only `region` was validated
(via `isValidRegion`); this change adds an equivalent `isValidClusterId`
check so `clusterId` is restricted to alphanumeric characters, hyphens, and
underscores before it is used to generate notebook cell content. Malformed
values are rejected with a user-facing error.

Since `extension.ts` is generated at build time from the quilt patch series,
the change is made in `patches/sagemaker/sagemaker-open-notebook-extension.diff`
and regenerated with `quilt refresh` (no other files change).

## Testing

- Regenerated the patched source via `scripts/prepare-src.sh`; the full patch
  series applies cleanly and the generated `extension.ts` contains the new
  `isValidClusterId` validator and the guard in `loadAndDisplayNotebook`.
- Type-checked the edited extension with `tsc --noEmit`; no errors on the
  change (only environmental module-resolution messages from the uninstalled
  toolchain).
- Confirmed valid IDs (e.g. `ml-cluster-123`) are accepted and values
  containing shell metacharacters, spaces, or newlines are rejected.

## Screenshots/Videos

N/A

## Additional Notes

Minimal, low-risk input-validation change that mirrors the existing
`isValidRegion` pattern already in the extension.

## Backporting

This change applies to the other active version branches. Separate PRs will be
raised for `main`, `1.2`, and `1.0`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
