### PR TITLE
chore: override tar to ^7.5.19, shell-quote to ^1.9.0, axios to ^1.18.0, brace-expansion to ^5.0.8

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -3940,7 +3940,7 @@ GitHub Copilot CLI License
 
 ******************************
 
-@github/copilot-linux-x64
+@github/copilot-linux-arm64
 1.0.50 <https://github.com/github/copilot-cli>
 GitHub Copilot CLI License
 
@@ -3981,7 +3981,7 @@ GitHub Copilot CLI License
 
 ******************************
 
-@github/copilot-linuxmusl-x64
+@github/copilot-linuxmusl-arm64
 1.0.50 <https://github.com/github/copilot-cli>
 GitHub Copilot CLI License
 
@@ -5716,7 +5716,7 @@ SOFTWARE.
 ******************************
 
 axios
-1.16.1 <https://github.com/axios/axios>
+1.18.1 <https://github.com/axios/axios>
 # Copyright (c) 2014-present Matt Zabriskie & Collaborators
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -9082,7 +9082,7 @@ SOFTWARE.
 ******************************
 
 shell-quote
-1.8.4 <https://github.com/ljharb/shell-quote>
+1.10.0 <https://github.com/ljharb/shell-quote>
 The MIT License
 
 Copyright (c) 2013 James Halliday (mail@substack.net)
@@ -9275,7 +9275,7 @@ software or this license, under any kind of legal claim.***
 ******************************
 
 tar
-7.5.16 <https://github.com/isaacs/node-tar>
+7.5.22 <https://github.com/isaacs/node-tar>
 # Blue Oak Model License
 
 Version 1.0.0

--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -3940,7 +3940,7 @@ GitHub Copilot CLI License
 
 ******************************
 
-@github/copilot-linux-arm64
+@github/copilot-linux-x64
 1.0.50 <https://github.com/github/copilot-cli>
 GitHub Copilot CLI License
 
@@ -3981,7 +3981,7 @@ GitHub Copilot CLI License
 
 ******************************
 
-@github/copilot-linuxmusl-arm64
+@github/copilot-linuxmusl-x64
 1.0.50 <https://github.com/github/copilot-cli>
 GitHub Copilot CLI License
 

--- a/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
@@ -85,15 +85,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chalk": {

--- a/build-tools/oss-attribution/oss-attribution-generator/package.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package.json
@@ -4,6 +4,6 @@
   },
   "overrides": {
     "minimatch": "^10.2.3",
-    "brace-expansion": "^5.0.6"
+    "brace-expansion": "^5.0.8"
   }
 }

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -3940,7 +3940,7 @@ GitHub Copilot CLI License
 
 ******************************
 
-@github/copilot-linux-x64
+@github/copilot-linux-arm64
 1.0.50 <https://github.com/github/copilot-cli>
 GitHub Copilot CLI License
 
@@ -3981,7 +3981,7 @@ GitHub Copilot CLI License
 
 ******************************
 
-@github/copilot-linuxmusl-x64
+@github/copilot-linuxmusl-arm64
 1.0.50 <https://github.com/github/copilot-cli>
 GitHub Copilot CLI License
 
@@ -5716,7 +5716,7 @@ SOFTWARE.
 ******************************
 
 axios
-1.16.1 <https://github.com/axios/axios>
+1.18.1 <https://github.com/axios/axios>
 # Copyright (c) 2014-present Matt Zabriskie & Collaborators
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -9082,7 +9082,7 @@ SOFTWARE.
 ******************************
 
 shell-quote
-1.8.4 <https://github.com/ljharb/shell-quote>
+1.10.0 <https://github.com/ljharb/shell-quote>
 The MIT License
 
 Copyright (c) 2013 James Halliday (mail@substack.net)
@@ -9275,7 +9275,7 @@ software or this license, under any kind of legal claim.***
 ******************************
 
 tar
-7.5.16 <https://github.com/isaacs/node-tar>
+7.5.22 <https://github.com/isaacs/node-tar>
 # Blue Oak Model License
 
 Version 1.0.0

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -3940,7 +3940,7 @@ GitHub Copilot CLI License
 
 ******************************
 
-@github/copilot-linux-arm64
+@github/copilot-linux-x64
 1.0.50 <https://github.com/github/copilot-cli>
 GitHub Copilot CLI License
 
@@ -3981,7 +3981,7 @@ GitHub Copilot CLI License
 
 ******************************
 
-@github/copilot-linuxmusl-arm64
+@github/copilot-linuxmusl-x64
 1.0.50 <https://github.com/github/copilot-cli>
 GitHub Copilot CLI License
 

--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -61,7 +61,7 @@
         "open": "^10.1.2",
         "playwright-core": "1.59.1",
         "ssh2": "^1.16.0",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "tas-client": "0.3.1",
         "undici": "^7.28.0",
         "vscode-oniguruma": "1.7.0",
@@ -165,7 +165,7 @@
         "sinon-test": "^3.1.3",
         "source-map": "0.6.1",
         "source-map-support": "^0.5.21",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "tsec": "0.2.7",
         "tslib": "^2.6.3",
         "typescript": "^6.0.0-dev.20260416",
@@ -4954,9 +4954,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -16621,9 +16621,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17794,9 +17794,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package-lock-overrides/sagemaker.series/remote/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/remote/package-lock.json
@@ -1256,9 +1256,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1320,9 +1320,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -4941,9 +4941,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -16589,9 +16589,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
@@ -1209,9 +1209,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -4941,9 +4941,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -16589,9 +16589,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-embedded.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/remote/package-lock.json
@@ -1209,9 +1209,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -4953,9 +4953,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -16620,9 +16620,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock-overrides/web-server.series/remote/package-lock.json
+++ b/package-lock-overrides/web-server.series/remote/package-lock.json
@@ -1256,9 +1256,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/patches/common/finding-override-axios.diff
+++ b/patches/common/finding-override-axios.diff
@@ -1,9 +1,9 @@
-Override axios to ^1.15.2.
-Remove when upstream Code-OSS updates axios to >= 1.15.2.
+Override axios to ^1.18.0.
+Remove when upstream Code-OSS updates axios to >= 1.18.0.
 
 @generated
-@generator: scripts/patches/apply-override.sh --patch common/finding-override-axios.diff --override 'global:axios=^1.15.2'
-@override-package: axios@^1.15.2
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-axios.diff --override 'global:axios=^1.18.0'
+@override-package: axios@^1.18.0
 
 Index: b/package.json
 ===================================================================
@@ -15,7 +15,7 @@ Index: b/package.json
      "uuid": "^14.0.0",
 -    "ip-address": "^10.1.1"
 +    "ip-address": "^10.1.1",
-+    "axios": "^1.15.2"
++    "axios": "^1.18.0"
    },
    "repository": {
      "type": "git",

--- a/patches/common/finding-override-shell-quote.diff
+++ b/patches/common/finding-override-shell-quote.diff
@@ -1,10 +1,9 @@
-Override shell-quote to ^1.8.4.
-Regenerate: npx ts-node build-tools/apply-finding-overrides/apply-finding-overrides.ts apply --patch common/finding-override-shell-quote.diff --override global:shell-quote=^1.8.4 --override remote/package.json@global:shell-quote=^1.8.4
-Remove when upstream Code-OSS updates shell-quote to >= 1.8.4.
+Override shell-quote to ^1.9.0.
+Remove when upstream Code-OSS updates shell-quote to >= 1.9.0.
 
 @generated
-@generator: scripts/patches/apply-override.sh --patch common/finding-override-shell-quote.diff --override 'global:shell-quote=^1.8.4' --override 'remote/package.json@global:shell-quote=^1.8.4'
-@override-package: shell-quote@^1.8.4
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-shell-quote.diff --override 'global:shell-quote=^1.9.0' --override 'remote/package.json@global:shell-quote=^1.9.0'
+@override-package: shell-quote@^1.9.0
 
 Index: b/package.json
 ===================================================================
@@ -14,7 +13,7 @@ Index: b/package.json
      "yaserver": "^0.4.0"
    },
    "overrides": {
-+    "shell-quote": "^1.8.4",
++    "shell-quote": "^1.9.0",
      "postcss": "^8.4.31",
      "node-gyp-build": "4.8.1",
      "serialize-javascript": "^7.0.3",
@@ -26,7 +25,7 @@ Index: b/remote/package.json
      "yazl": "^2.4.3"
    },
    "overrides": {
-+    "shell-quote": "^1.8.4",
++    "shell-quote": "^1.9.0",
      "node-gyp-build": "4.8.1",
      "ssh2": {
        "cpu-features": "0.0.0"

--- a/patches/common/finding-override-tar.diff
+++ b/patches/common/finding-override-tar.diff
@@ -1,8 +1,8 @@
-Override tar to ^7.5.16 to fix CVE-2026-53655.
+Override tar to ^7.5.19.
 
 @generated
-@generator: scripts/patches/apply-override.sh --patch common/finding-override-tar.diff --override 'direct:tar=^7.5.16' --override 'direct-dev:tar=^7.5.16' --override 'remote/package.json@global:tar=^7.5.16'
-@override-package: tar@^7.5.16
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-tar.diff --override 'direct:tar=^7.5.19' --override 'direct-dev:tar=^7.5.19' --override 'remote/package.json@global:tar=^7.5.19'
+@override-package: tar@^7.5.19
 
 Index: b/package.json
 ===================================================================
@@ -14,7 +14,7 @@ Index: b/package.json
      "yauzl": "^3.0.0",
 -    "yazl": "^2.4.3"
 +    "yazl": "^2.4.3",
-+    "tar": "^7.5.16"
++    "tar": "^7.5.19"
    },
    "devDependencies": {
      "@playwright/cli": "^0.1.9",
@@ -23,7 +23,7 @@ Index: b/package.json
      "source-map": "0.6.1",
      "source-map-support": "^0.5.21",
 -    "tar": "^7.5.9",
-+    "tar": "^7.5.16",
++    "tar": "^7.5.19",
      "tsec": "0.2.7",
      "tslib": "^2.6.3",
      "typescript": "^6.0.0-dev.20260416",
@@ -37,6 +37,6 @@ Index: b/remote/package.json
      "@github/copilot": "^1.0.43",
 -    "undici": "^7.28.0"
 +    "undici": "^7.28.0",
-+    "tar": "^7.5.16"
++    "tar": "^7.5.19"
    }
  }

--- a/patches/common/finding-override-ws.diff
+++ b/patches/common/finding-override-ws.diff
@@ -1,4 +1,5 @@
-Override ws to ^8.21.0 and nested chrome-remote-interface ws to ^7.5.11 to fix CVE-2026-48779.
+Override ws to ^8.21.0 and nested chrome-remote-interface ws to ^7.5.11.
+Remove when upstream Code-OSS updates ws to >= 8.21.0.
 
 @generated
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-ws.diff --override 'direct:ws=^8.21.0' --override 'remote/package.json@direct:ws=^8.21.0' --override 'nested:chrome-remote-interface:ws=^7.5.11'
@@ -22,8 +23,8 @@ Index: b/package.json
      "follow-redirects": "^1.16.0",
      "uuid": "^14.0.0",
      "ip-address": "^10.1.1",
--    "axios": "^1.15.2"
-+    "axios": "^1.15.2",
+-    "axios": "^1.18.0"
++    "axios": "^1.18.0",
 +    "chrome-remote-interface": {
 +      "ws": "^7.5.11"
 +    }


### PR DESCRIPTION
## Issue


## Description of Changes
Bumps npm dependency override versions flagged by the nightly Security Scan (Amazon Inspector, `code-editor-sagemaker-server` target) and regenerates the affected package-lock overrides + OSS attribution.

- `tar`: `^7.5.16` → `^7.5.19`
- `shell-quote`: `^1.8.4` → `^1.9.0`
- `axios`: `^1.15.2` → `^1.18.0`
- `brace-expansion` (in `build-tools/oss-attribution/oss-attribution-generator`): `^5.0.6` → `^5.0.8`

The `finding-override-ws.diff` patch is refreshed only to update its context around the `axios` line (the `ws` override versions are unchanged: `ws ^8.21.0`, nested `chrome-remote-interface` `ws ^7.5.11`).

## Testing
- `./scripts/prepare-src.sh code-editor-sagemaker-server` applies the full patch series cleanly.
- `./scripts/update-package-locks.sh` regenerates lockfiles + OSS attribution for all four targets with no errors.
- Verified resolved versions in `package-lock-overrides/sagemaker.series/package-lock.json` (and `remote/`): `tar` 7.5.22, `axios` 1.18.1, `shell-quote` 1.10.0, top-level `ws` 8.21.0 — all at or above the required fixed versions. `brace-expansion` resolves to 5.0.8 in the build-tool lockfile.

## Screenshots/Videos
N/A

## Additional Notes
Override-only change; no source/behavior changes. Follows the established `finding-override-*.diff` pattern (e.g. the prior undici/ws/form-data override PR). Patch headers use the deterministic `@generator` metadata so they can be regenerated on upstream bumps.

## Backporting
The same fix is being raised in parallel against `main`, `1.0`, `1.1`, and `1.2`. The set of affected packages differs per branch (older branches were only flagged for `tar` and `brace-expansion`).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
