### PR TITLE
chore: override tar to ^7.5.19, brace-expansion to ^5.0.8

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -6547,7 +6547,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************
 
 tar
-7.5.16 <https://github.com/isaacs/node-tar>
+7.5.22 <https://github.com/isaacs/node-tar>
 # Blue Oak Model License
 
 Version 1.0.0

--- a/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
@@ -85,15 +85,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chalk": {

--- a/build-tools/oss-attribution/oss-attribution-generator/package.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package.json
@@ -4,6 +4,6 @@
   },
   "overrides": {
     "minimatch": "^10.2.3",
-    "brace-expansion": "^5.0.6"
+    "brace-expansion": "^5.0.8"
   }
 }

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -6547,7 +6547,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************
 
 tar
-7.5.16 <https://github.com/isaacs/node-tar>
+7.5.22 <https://github.com/isaacs/node-tar>
 # Blue Oak Model License
 
 Version 1.0.0

--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -148,7 +148,7 @@
         "source-map": "0.6.1",
         "source-map-support": "^0.3.2",
         "style-loader": "^3.3.2",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.1",
         "tsec": "0.2.7",
@@ -15276,9 +15276,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -146,7 +146,7 @@
         "source-map": "0.6.1",
         "source-map-support": "^0.3.2",
         "style-loader": "^3.3.2",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.1",
         "tsec": "0.2.7",
@@ -15242,9 +15242,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -146,7 +146,7 @@
         "source-map": "0.6.1",
         "source-map-support": "^0.3.2",
         "style-loader": "^3.3.2",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.1",
         "tsec": "0.2.7",
@@ -15242,9 +15242,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -148,7 +148,7 @@
         "source-map": "0.6.1",
         "source-map-support": "^0.3.2",
         "style-loader": "^3.3.2",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.1",
         "tsec": "0.2.7",
@@ -15293,9 +15293,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/patches/common/finding-override-tar.diff
+++ b/patches/common/finding-override-tar.diff
@@ -1,8 +1,8 @@
-Override tar to ^7.5.16 to fix CVE-2026-53655.
+Override tar to ^7.5.19.
 
 @generated
-@generator: scripts/patches/apply-override.sh --patch common/finding-override-tar.diff --override 'direct-dev:tar=^7.5.16' --override 'global:tar=^7.5.16'
-@override-package: tar@^7.5.16
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-tar.diff --override 'direct-dev:tar=^7.5.19' --override 'global:tar=^7.5.19'
+@override-package: tar@^7.5.19
 
 Index: b/package.json
 ===================================================================
@@ -13,7 +13,7 @@ Index: b/package.json
      "source-map-support": "^0.3.2",
      "style-loader": "^3.3.2",
 -    "tar": "^7.5.10",
-+    "tar": "^7.5.16",
++    "tar": "^7.5.19",
      "ts-loader": "^9.5.1",
      "ts-node": "^10.9.1",
      "tsec": "0.2.7",
@@ -23,7 +23,7 @@ Index: b/package.json
      "undici": "^7.28.0",
 -    "ws": "^7.5.11"
 +    "ws": "^7.5.11",
-+    "tar": "^7.5.16"
++    "tar": "^7.5.19"
    },
    "repository": {
      "type": "git",


### PR DESCRIPTION
## Issue


## Description of Changes
Bumps npm dependency override versions flagged by the nightly Security Scan (Amazon Inspector, `code-editor-sagemaker-server` target) and regenerates the affected package-lock overrides + OSS attribution.

- `tar`: `^7.5.16` → `^7.5.19`
- `brace-expansion` (in `build-tools/oss-attribution/oss-attribution-generator`): `^5.0.6` → `^5.0.8`

## Testing
- `./scripts/prepare-src.sh code-editor-sagemaker-server` applies the full patch series cleanly.
- `./scripts/update-package-locks.sh` regenerates lockfiles + OSS attribution for all four targets with no errors.
- Verified resolved `tar` version in `package-lock-overrides/sagemaker.series/package-lock.json` is at or above the required fixed version (7.5.22). `brace-expansion` resolves to 5.0.8 in the build-tool lockfile.

## Screenshots/Videos
N/A

## Additional Notes
Override-only change; no source/behavior changes. Follows the established `finding-override-*.diff` pattern. The `tar` override on this branch uses the branch's existing generator signature (`direct-dev` + `global`, root only).

## Backporting
The same fix is being raised in parallel against `main`, `1.0`, `1.1`, and `1.2`. Newer branches (`main`, `1.2`) additionally bump `shell-quote` and `axios`, which were only flagged there.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
