### PR TITLE
fix: backport upstream VS Code advisory fixes (copilot config scope, iframe parentOrigin, notebook render)

### DIFF
--- a/patches/backported-patches.json
+++ b/patches/backported-patches.json
@@ -48,5 +48,45 @@
     "patch_path": "N/A",
     "link": "https://github.com/advisories/GHSA-c82g-9gj4-hxp2",
     "note": "GitHub Copilot path traversal - Copilot not present in Code Editor"
+  },
+  {
+    "finding_id": "CVE-2026-47282",
+    "affected_versions": "< 1.128.1",
+    "patch_path": "patches/common/fix-copilot-debug-override-user-scope.diff",
+    "link": "https://github.com/microsoft/vscode/commit/f05bcd1aa29cff28a62fe137b4a16fec9393f31b"
+  },
+  {
+    "finding_id": "GHSA-wr9x-42j2-jvh3",
+    "affected_versions": "< 1.128.1",
+    "patch_path": "patches/common/fix-copilot-debug-override-user-scope.diff",
+    "link": "https://github.com/microsoft/vscode/commit/f05bcd1aa29cff28a62fe137b4a16fec9393f31b"
+  },
+  {
+    "finding_id": "CVE-2026-57102",
+    "affected_versions": "< 1.128.1",
+    "patch_path": "patches/web-server/webview.diff",
+    "link": "https://github.com/microsoft/vscode/commit/236fa7d8ea86f0f4261df38e1a17b3c7e7002bd0",
+    "note": "Attacker-controlled parentOrigin RCE in the web worker extension host iframe. Already mitigated by the existing web-server/webview.diff: the iframe script forces parentOrigin = window.origin and only reads the searchParams parentOrigin after the hostname-validation branch, so the non-validated (same-origin) path never trusts an attacker-supplied parentOrigin. Equivalent to upstream's explicit rejection; not double-applied."
+  },
+  {
+    "finding_id": "GHSA-v282-cxqj-xgj4",
+    "affected_versions": "< 1.128.1",
+    "patch_path": "patches/web-server/webview.diff",
+    "link": "https://github.com/microsoft/vscode/commit/236fa7d8ea86f0f4261df38e1a17b3c7e7002bd0",
+    "note": "Attacker-controlled parentOrigin RCE in the web worker extension host iframe. Already mitigated by the existing web-server/webview.diff: the iframe script forces parentOrigin = window.origin and only reads the searchParams parentOrigin after the hostname-validation branch, so the non-validated (same-origin) path never trusts an attacker-supplied parentOrigin. Equivalent to upstream's explicit rejection; not double-applied."
+  },
+  {
+    "finding_id": "CVE-2026-57101",
+    "affected_versions": "< 1.128.1",
+    "patch_path": "N/A",
+    "link": "https://github.com/microsoft/vscode/commit/bc2d56c6f8da22a4bd31f741fcb034208770f158",
+    "note": "Notebook Restricted-Mode bypass via mermaid render. Upstream vulnerable file extensions/mermaid-markdown-features/preview-src/notebook/index.ts (the 'temp.innerHTML = result' sink and renderMermaidBlocksInElement) does not exist in this branch's shipped source. The only mermaid extension here, mermaid-chat-features, renders diagrams via escapeHtmlText() into a <pre> and uses textContent (chat-webview-src/mermaidWebview.ts) inside a sandboxed webview with strict nonce CSP - no innerHTML of untrusted content. The markdown-language-features notebook renderer already sanitizes untrusted HTML with DOMPurify. No equivalent vulnerable innerHTML/insertAdjacentHTML sink for untrusted render output exists."
+  },
+  {
+    "finding_id": "GHSA-9mw4-h26x-gfxw",
+    "affected_versions": "< 1.128.1",
+    "patch_path": "N/A",
+    "link": "https://github.com/microsoft/vscode/commit/bc2d56c6f8da22a4bd31f741fcb034208770f158",
+    "note": "Notebook Restricted-Mode bypass via mermaid render. Upstream vulnerable file extensions/mermaid-markdown-features/preview-src/notebook/index.ts (the 'temp.innerHTML = result' sink and renderMermaidBlocksInElement) does not exist in this branch's shipped source. The only mermaid extension here, mermaid-chat-features, renders diagrams via escapeHtmlText() into a <pre> and uses textContent (chat-webview-src/mermaidWebview.ts) inside a sandboxed webview with strict nonce CSP - no innerHTML of untrusted content. The markdown-language-features notebook renderer already sanitizes untrusted HTML with DOMPurify. No equivalent vulnerable innerHTML/insertAdjacentHTML sink for untrusted render output exists."
   }
 ]

--- a/patches/common/fix-copilot-debug-override-user-scope.diff
+++ b/patches/common/fix-copilot-debug-override-user-scope.diff
@@ -1,0 +1,164 @@
+Restrict Copilot debug endpoint override settings to user (global) scope.
+Reads the advanced debug CAPI/proxy URL override settings only from the user
+(global) configuration, ignoring workspace and folder values so a malicious
+workspace .vscode/settings.json cannot redirect requests to an attacker host.
+Remove when Code-OSS is updated to >= 1.128.1.
+
+@backported: https://github.com/microsoft/vscode/commit/f05bcd1aa29cff28a62fe137b4a16fec9393f31b
+@finding-id: CVE-2026-47282 GHSA-wr9x-42j2-jvh3
+Index: b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
+===================================================================
+--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
++++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
+@@ -15,7 +15,8 @@ import {
+ 	getOptionalConfigDefaultForKey,
+ 	ICompletionsConfigProvider,
+ 	ICompletionsEditorAndPluginInfo,
+-	packageJson
++	packageJson,
++	userScopeOnlyKeys
+ } from '../../lib/src/config';
+ import { CopilotConfigPrefix } from '../../lib/src/constants';
+ import { Logger } from '../../lib/src/logger';
+@@ -44,13 +45,38 @@ export class VSCodeConfigProvider extend
+ 	}
+ 
+ 	override getConfig<T>(key: ConfigKeyType): T {
++		if (userScopeOnlyKeys.has(key)) {
++			return this._getUserScopeValue<T>(key) ?? getConfigDefaultForKey(key);
++		}
+ 		return getConfigKeyRecursively<T>(this.config, key) ?? getConfigDefaultForKey(key);
+ 	}
+ 
+ 	override getOptionalConfig<T>(key: ConfigKeyType): T | undefined {
++		if (userScopeOnlyKeys.has(key)) {
++			return this._getUserScopeValue<T>(key) ?? getOptionalConfigDefaultForKey(key);
++		}
+ 		return getConfigKeyRecursively<T>(this.config, key) ?? getOptionalConfigDefaultForKey(key);
+ 	}
+ 
++	private _getUserScopeValue<T>(key: ConfigKeyType): T | undefined {
++		// Try the flat key path directly
++		const inspected = this.config.inspect<T>(key);
++		if (inspected?.globalValue !== undefined) {
++			return inspected.globalValue;
++		}
++		// Handle object-style settings (e.g., "advanced": { "debug.overrideCapiUrl": "..." })
++		const firstDot = key.indexOf('.');
++		if (firstDot > 0) {
++			const parentKey = key.substring(0, firstDot);
++			const subKey = key.substring(firstDot + 1);
++			const parentInspect = this.config.inspect<Record<string, unknown>>(parentKey);
++			if (parentInspect?.globalValue && typeof parentInspect.globalValue === 'object') {
++				return getConfigKeyRecursively<T>(parentInspect.globalValue as Record<string, unknown>, subKey);
++			}
++		}
++		return undefined;
++	}
++
+ 	// Dumps config settings defined in the extension json
+ 	override dumpForTelemetry(): { [key: string]: string } {
+ 		return {};
+Index: b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
+===================================================================
+--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
++++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
+@@ -75,6 +75,21 @@ export const ConfigKey = {
+ 	UseSplitContextPrompt: 'internal.useSplitContextPrompt',
+ };
+ 
++/**
++ * Settings that must only be read from user (global) scope, ignoring workspace/folder values.
++ * Prevents workspace-level override attacks via malicious .vscode/settings.json.
++ */
++export const userScopeOnlyKeys = new Set<ConfigKeyType>([
++	ConfigKey.DebugOverrideCapiUrl,
++	ConfigKey.DebugOverrideCapiUrlLegacy,
++	ConfigKey.DebugTestOverrideCapiUrl,
++	ConfigKey.DebugTestOverrideCapiUrlLegacy,
++	ConfigKey.DebugOverrideProxyUrl,
++	ConfigKey.DebugOverrideProxyUrlLegacy,
++	ConfigKey.DebugTestOverrideProxyUrl,
++	ConfigKey.DebugTestOverrideProxyUrlLegacy,
++]);
++
+ export type ConfigKeyType = string;
+ 
+ // How to determine where to terminate the completion to the current block.
+Index: b/extensions/copilot/src/platform/configuration/common/configurationService.ts
+===================================================================
+--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
++++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
+@@ -375,6 +375,12 @@ export const enum ConfigType {
+ export interface ConfigOptions {
+ 	readonly oldKey?: string;
+ 	readonly valueIgnoredForExternals?: boolean;
++	/**
++	 * When true, only reads from user (global) scope, ignoring workspace and folder values.
++	 * Use for security-sensitive settings (e.g., API endpoint overrides) that must not be
++	 * controllable via a workspace's .vscode/settings.json.
++	 */
++	readonly userScopeOnly?: boolean;
+ }
+ 
+ export interface Config<T> extends BaseConfig<T> {
+@@ -573,8 +579,8 @@ export namespace ConfigKey {
+ 	*/
+ 	export namespace Shared {
+ 		/** Allows for overriding the base domain we use for making requests to the CAPI. This helps CAPI devs develop against a local instance. */
+-		export const DebugOverrideProxyUrl = defineSetting<string | undefined>('advanced.debug.overrideProxyUrl', ConfigType.Simple, undefined);
+-		export const DebugOverrideCAPIUrl = defineSetting<string | undefined>('advanced.debug.overrideCapiUrl', ConfigType.Simple, undefined);
++		export const DebugOverrideProxyUrl = defineSetting<string | undefined>('advanced.debug.overrideProxyUrl', ConfigType.Simple, undefined, undefined, { userScopeOnly: true });
++		export const DebugOverrideCAPIUrl = defineSetting<string | undefined>('advanced.debug.overrideCapiUrl', ConfigType.Simple, undefined, undefined, { userScopeOnly: true });
+ 		export const DebugUseNodeFetchFetcher = defineSetting('advanced.debug.useNodeFetchFetcher', ConfigType.Simple, true);
+ 		export const DebugUseNodeFetcher = defineSetting('advanced.debug.useNodeFetcher', ConfigType.Simple, false);
+ 		export const DebugUseElectronFetcher = defineSetting('advanced.debug.useElectronFetcher', ConfigType.Simple, true);
+Index: b/extensions/copilot/src/platform/configuration/vscode/configurationServiceImpl.ts
+===================================================================
+--- a/extensions/copilot/src/platform/configuration/vscode/configurationServiceImpl.ts
++++ b/extensions/copilot/src/platform/configuration/vscode/configurationServiceImpl.ts
+@@ -57,7 +57,9 @@ export class ConfigurationServiceImpl ex
+ 		const config = scope === undefined ? this.config : vscode.workspace.getConfiguration(CopilotConfigPrefix, scope);
+ 
+ 		let configuredValue: T | undefined;
+-		if (key.advancedSubKey) {
++		if (key.options?.userScopeOnly) {
++			configuredValue = this._getUserScopeValue(config, key);
++		} else if (key.advancedSubKey) {
+ 			// This is a `github.copilot.advanced.*` setting
+ 
+ 			// First, let's try to read it using the flat style
+@@ -104,6 +106,33 @@ export class ConfigurationServiceImpl ex
+ 		return value.content;
+ 	}
+ 
++	private _getUserScopeValue<T>(config: WorkspaceConfiguration, key: Config<T>): T | undefined {
++		if (key.advancedSubKey) {
++			// Flat style: e.g., "github.copilot.advanced.debug.overrideCapiUrl": "..."
++			const flatInspect = config.inspect<T>(key.id);
++			if (flatInspect?.globalValue !== undefined) {
++				return flatInspect.globalValue;
++			}
++			// Object style: e.g., "github.copilot.advanced": { "debug.overrideCapiUrl": "..." }
++			const advancedInspect = config.inspect<Record<string, any>>('advanced');
++			return advancedInspect?.globalValue?.[key.advancedSubKey];
++		}
++
++		const inspected = config.inspect<T>(key.id);
++		if (inspected?.globalValue !== undefined) {
++			return inspected.globalValue;
++		}
++
++		if (key.oldId) {
++			const oldInspected = config.inspect<T>(key.oldId);
++			if (oldInspected?.globalValue !== undefined) {
++				return oldInspected.globalValue;
++			}
++		}
++
++		return undefined;
++	}
++
+ 	inspectConfig<T>(key: BaseConfig<T>, scope?: vscode.ConfigurationScope): InspectConfigResult<T> | undefined {
+ 		if (key.options?.valueIgnoredForExternals && !this._isInternal) {
+ 			return { defaultValue: this.getDefaultValue(key) };

--- a/patches/sagemaker.series
+++ b/patches/sagemaker.series
@@ -71,3 +71,4 @@ common/fix-remote-hosts-loopback.diff
 common/finding-override-undici.diff
 common/finding-override-form-data.diff
 common/finding-override-tar.diff
+common/fix-copilot-debug-override-user-scope.diff

--- a/patches/web-embedded-with-terminal.series
+++ b/patches/web-embedded-with-terminal.series
@@ -67,3 +67,4 @@ common/fix-snippets-path-traversal.diff
 common/fix-remote-hosts-loopback.diff
 common/finding-override-undici.diff
 common/finding-override-form-data.diff
+common/fix-copilot-debug-override-user-scope.diff

--- a/patches/web-embedded.series
+++ b/patches/web-embedded.series
@@ -70,3 +70,4 @@ common/fix-snippets-path-traversal.diff
 common/fix-remote-hosts-loopback.diff
 common/finding-override-undici.diff
 common/finding-override-form-data.diff
+common/fix-copilot-debug-override-user-scope.diff

--- a/patches/web-server.series
+++ b/patches/web-server.series
@@ -49,3 +49,4 @@ common/fix-snippets-path-traversal.diff
 common/fix-remote-hosts-loopback.diff
 common/finding-override-undici.diff
 common/finding-override-form-data.diff
+common/fix-copilot-debug-override-user-scope.diff


### PR DESCRIPTION
## Issue


## Description of Changes
Addresses the upstream `microsoft/vscode` security advisories flagged by the "Scan GitHub Security Advisories" step of the nightly Security Scan (all fixed upstream in VS Code 1.128.1), by backporting the upstream fixes where the affected code ships and registering each finding in `patches/backported-patches.json`.

- **Copilot debug endpoint override hardening** — backports upstream [`f05bcd1a`](https://github.com/microsoft/vscode/commit/f05bcd1aa29cff28a62fe137b4a16fec9393f31b): the advanced debug CAPI/proxy URL override settings are now read only from user (global) configuration, so a malicious workspace `.vscode/settings.json` cannot redirect requests to an attacker host. New quilt patch under `patches/common/`, added to all four series.
- **Extension host iframe `parentOrigin` validation** — the existing `patches/web-server/webview.diff` already forces `parentOrigin` to `window.origin` in the non-validated path (equivalent to upstream [`236fa7d8`](https://github.com/microsoft/vscode/commit/236fa7d8ea86f0f4261df38e1a17b3c7e7002bd0)); registered as backported, no code change.
- **Notebook mermaid render** — upstream [`bc2d56c6`](https://github.com/microsoft/vscode/commit/bc2d56c6f8da22a4bd31f741fcb034208770f158) targets an extension not present in Code Editor; the shipped mermaid extension renders via `textContent`/escaped HTML and the markdown notebook renderer uses DOMPurify, so there is no equivalent unsafe sink. Registered with a `patch_path: "N/A"` evidence note.

## Testing
- `./scripts/prepare-src.sh code-editor-sagemaker-server` (and `code-editor-server`) apply the full patch series cleanly, including the new Copilot patch (no rejects).
- `./scripts/security-scan.sh scan-github-advisories` reports **0 concerning advisories** (all three findings recognized as backported/handled).

## Screenshots/Videos
N/A

## Additional Notes
Backport patch carries `@backported` + `@finding-id` metadata for the rebase tooling and future removal (remove when Code-OSS ≥ 1.128.1). The same fix is being raised in parallel against the other active branches; the set of applicable changes differs per branch (older branches do not ship the Copilot extension).

## Backporting
Raised in parallel against `main`, `1.0`, `1.1`, and `1.2`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
