### PR TITLE
fix: register upstream VS Code advisory reconciliations (iframe parentOrigin already patched; copilot/mermaid not shipped)

### DIFF
--- a/patches/backported-patches.json
+++ b/patches/backported-patches.json
@@ -98,5 +98,47 @@
         "patch_path": "N/A",
         "link": "https://github.com/advisories/GHSA-c82g-9gj4-hxp2",
         "note": "GitHub Copilot path traversal - Copilot not present in Code Editor"
+    },
+    {
+        "finding_id": "CVE-2026-47282",
+        "affected_versions": "< 1.128.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/microsoft/vscode/commit/f05bcd1aa29cff28a62fe137b4a16fec9393f31b",
+        "note": "Copilot completions config not present in Code Editor 1.108.2. Searched third-party-src for overrideCapiUrl/overrideProxyUrl, userScopeOnlyKeys, ICompletionsConfigProvider/VSCodeConfigProvider, and any copilot completions-core config code; none present (only unrelated terminal-suggest/typescript-language-features copilot helpers exist)."
+    },
+    {
+        "finding_id": "GHSA-wr9x-42j2-jvh3",
+        "affected_versions": "< 1.128.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/microsoft/vscode/commit/f05bcd1aa29cff28a62fe137b4a16fec9393f31b",
+        "note": "Copilot completions config not present in Code Editor 1.108.2. Searched third-party-src for overrideCapiUrl/overrideProxyUrl, userScopeOnlyKeys, ICompletionsConfigProvider/VSCodeConfigProvider, and any copilot completions-core config code; none present (only unrelated terminal-suggest/typescript-language-features copilot helpers exist)."
+    },
+    {
+        "finding_id": "CVE-2026-57101",
+        "affected_versions": "< 1.128.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/microsoft/vscode/commit/bc2d56c6f8da22a4bd31f741fcb034208770f158",
+        "note": "Vulnerable mermaid notebook renderer (extensions/mermaid-markdown-features/preview-src/notebook/index.ts, 'temp.innerHTML = result') not present in Code Editor 1.108.2. Shipped mermaid-chat-features webview uses textContent (safe); markdown-language-features notebook renderer already DOMPurify-sanitizes untrusted HTML. No equivalent unsafe innerHTML-of-untrusted-content render found."
+    },
+    {
+        "finding_id": "GHSA-9mw4-h26x-gfxw",
+        "affected_versions": "< 1.128.1",
+        "patch_path": "N/A",
+        "link": "https://github.com/microsoft/vscode/commit/bc2d56c6f8da22a4bd31f741fcb034208770f158",
+        "note": "Vulnerable mermaid notebook renderer (extensions/mermaid-markdown-features/preview-src/notebook/index.ts, 'temp.innerHTML = result') not present in Code Editor 1.108.2. Shipped mermaid-chat-features webview uses textContent (safe); markdown-language-features notebook renderer already DOMPurify-sanitizes untrusted HTML. No equivalent unsafe innerHTML-of-untrusted-content render found."
+    },
+    {
+        "finding_id": "CVE-2026-57102",
+        "affected_versions": "< 1.128.1",
+        "patch_path": "patches/web-server/webview.diff",
+        "link": "https://github.com/microsoft/vscode/commit/236fa7d8ea86f0f4261df38e1a17b3c7e7002bd0",
+        "note": "Already mitigated by existing webview.diff: in the non-validated iframe path parentOrigin is forced to window.origin before start(), so an attacker-supplied parentOrigin search param is never honored (onmessage only accepts event.origin === parentOrigin). Equivalent to upstream's explicit parentOrigin rejection."
+    },
+    {
+        "finding_id": "GHSA-v282-cxqj-xgj4",
+        "affected_versions": "< 1.128.1",
+        "patch_path": "patches/web-server/webview.diff",
+        "link": "https://github.com/microsoft/vscode/commit/236fa7d8ea86f0f4261df38e1a17b3c7e7002bd0",
+        "note": "Already mitigated by existing webview.diff: in the non-validated iframe path parentOrigin is forced to window.origin before start(), so an attacker-supplied parentOrigin search param is never honored (onmessage only accepts event.origin === parentOrigin). Equivalent to upstream's explicit parentOrigin rejection."
     }
 ]


### PR DESCRIPTION
## Issue


## Description of Changes
Addresses the upstream `microsoft/vscode` security advisories flagged by the "Scan GitHub Security Advisories" step of the nightly Security Scan (all fixed upstream in VS Code 1.128.1) by registering each finding in `patches/backported-patches.json`. On this branch's pinned Code-OSS version, the affected code is either already mitigated by an existing patch or not shipped at all:

- **Extension host iframe `parentOrigin` validation** — already mitigated by the existing `patches/web-server/webview.diff`, which forces `parentOrigin` to `window.origin` in the non-validated path (equivalent to upstream [`236fa7d8`](https://github.com/microsoft/vscode/commit/236fa7d8ea86f0f4261df38e1a17b3c7e7002bd0)). Registered as backported; no code change.
- **Copilot debug endpoint override** ([`f05bcd1a`](https://github.com/microsoft/vscode/commit/f05bcd1aa29cff28a62fe137b4a16fec9393f31b)) — the Copilot completions extension and the affected config code are not shipped in this branch's version. Registered `patch_path: "N/A"` with an evidence note.
- **Notebook mermaid render** ([`bc2d56c6`](https://github.com/microsoft/vscode/commit/bc2d56c6f8da22a4bd31f741fcb034208770f158)) — the affected extension is not present; shipped renderers use safe `textContent`/DOMPurify. Registered `patch_path: "N/A"` with an evidence note.

## Testing
- `./scripts/prepare-src.sh code-editor-sagemaker-server` applies the full patch series cleanly (no rejects).
- Confirmed all three findings (CVE + GHSA ids) are present in `patches/backported-patches.json` so the advisory scan treats them as handled.

## Screenshots/Videos
N/A

## Additional Notes
The "not present" determinations were made by searching this branch's shipped source (no `mermaid-markdown-features`, no Copilot completions config, shipped renderers use safe APIs) — not by assumption. The same set of findings is raised in parallel against the other active branches; newer branches (`main`, `1.2`) additionally include a source backport for the Copilot fix, since that extension ships there.

## Backporting
Raised in parallel against `main`, `1.0`, `1.1`, and `1.2`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
