### PR TITLE
ci: fix generate-security-scan-output branch name resolution (main)

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -424,6 +424,14 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.get-branches-to-scan.outputs.security-scan-branches) }}
     steps:
+      - name: Sanitize branch name
+        id: branch-slug
+        run: |
+          slug=$(echo "${{ matrix.branch }}" | tr '/' '-' | cut -c1-28)
+          safe=$(echo "${{ matrix.branch }}" | tr '/' '-')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+          echo "safe=$safe" >> "$GITHUB_OUTPUT"
+
       - name: Download all scan success files
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
## Issue


## Description of Changes
CI logic fix (no security-scan behavior change). The `generate-security-scan-output` job in `.github/workflows/security-scan.yaml` referenced `${{ steps.branch-slug.outputs.safe }}` in three places (the `MATRIX_BRANCH` env and the branch success-file upload name/path), but that job never defined a `branch-slug` step — only the sibling `security-scan` and `security-scan-global-dependencies` jobs do.

As a result `MATRIX_BRANCH` resolved to an empty string, so the "Check if branch was successful for all targets" step looked for `scan-success-code-editor-sagemaker-server-.txt` (empty branch segment) while the actual uploaded artifact is `scan-success-code-editor-sagemaker-server-main.txt` — a filename mismatch that failed the job with exit 1 on every `main` run.

This change adds the same `Sanitize branch name` step (`id: branch-slug`) to the `generate-security-scan-output` job, mirroring the other two jobs, so the branch name resolves and the success-file names match.

## Testing
- YAML validated (`yaml.safe_load`).
- Verified the new `branch-slug` step is defined inside the `generate-security-scan-output` job before all three `steps.branch-slug.outputs.safe` references.
- With `matrix.branch = main`, `safe = main`, so the step now looks for `scan-success-code-editor-sagemaker-server-main.txt`, which matches the artifact produced by the `security-scan` job.

## Screenshots/Videos
N/A

## Additional Notes
Pre-existing bug on `main` only, introduced when this step was changed from `matrix.branch` to `steps.branch-slug.outputs.safe` (commit 6e2f17a0c). The version branches (1.0/1.1/1.2) still use `matrix.branch` directly and are unaffected. Independent of the recent SBOM/advisory security fixes — the actual `security-scan` and `security-scan-global-dependencies` jobs already pass; only this aggregation job was failing.

## Backporting
Not needed — the bug is specific to the `main` copy of the workflow; 1.0/1.1/1.2 do not have it.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
