### PR TITLE
fix: mark unused context parameter in post-startup-notifications activate

### DIFF
--- a/patches/sagemaker/post-startup-notifications.diff
+++ b/patches/sagemaker/post-startup-notifications.diff
@@ -270,7 +270,7 @@ Index: code-editor-src/extensions/post-startup-notifications/src/extension.ts
 +let watcher: chokidar.FSWatcher;
 +let outputChannel: vscode.OutputChannel;
 +
-+export function activate(context: vscode.ExtensionContext) {
++export function activate(_context: vscode.ExtensionContext) {
 +    // Check if in SageMaker Unified Studio
 +    const envValue = process.env[SERVICE_NAME_ENV_KEY];
 +


### PR DESCRIPTION
## Issue


## Description of Changes
Fixes a TypeScript compile break in the SageMaker build. The `code-editor-sagemaker-server` "Build artifacts" step fails with:

```
extensions/post-startup-notifications/src/extension.ts(11,26): error TS6133: 'context' is declared but its value is never read.
tsgo exited with code 2
```

The `post-startup-notifications` extension's `activate(context: vscode.ExtensionContext)` no longer references `context` in its body (its previous consumers were removed in #236), and the extension's tsconfig inherits `noUnusedParameters: true`, so the unused parameter is a hard compile error.

This change renames the parameter to the underscore-ignored form (`_context`) — the standard TypeScript convention for an intentionally-unused parameter — via the `patches/sagemaker/post-startup-notifications.diff` quilt patch. One-line change; no behavior change.

## Testing
- Reproduced the exact CI error against the extension's own `tsconfig.json` with `tsgo` (the same compiler the build uses): the original `context` param → `TS6133`.
- With the fix (`_context`): `tsgo --project ./tsconfig.json --noEmit` → exit 0, no diagnostics.
- Patch regenerated via quilt (not hand-edited); diff is a single line and preserves the repo's `code-editor-src/` path-prefix convention.

## Screenshots/Videos
N/A

## Additional Notes
Pre-existing latent break on `main` only: commit `5769285` (#236, 2026-06-10) removed the consumers of `context` but left the `activate` signature. `main` has #236; the `1.0`/`1.1`/`1.2` release branches do not, which is why only `main` fails to build. Unrelated to recent security-scan / dependency changes (those patches apply and compile cleanly). Surfaced now because this build ran against `main`.

## Backporting
Not needed for `1.0`/`1.1`/`1.2` (they don't contain #236). If #236 is ever cherry-picked to a release branch, this one-line fix should accompany it.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
