### PR TITLE
chore: override undici to ^7.29.0 and ip-address to ^10.3.1

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -7322,7 +7322,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 ******************************
 
 ip-address
-10.2.0 <https://github.com/beaugunderson/ip-address>
+10.4.0 <https://github.com/beaugunderson/ip-address>
 Copyright (C) 2011 by Beau Gunderson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -9553,7 +9553,7 @@ THE SOFTWARE.
 ******************************
 
 undici
-7.28.0 <https://github.com/nodejs/undici>
+7.29.0 <https://github.com/nodejs/undici>
 MIT License
 
 Copyright (c) Matteo Collina and Undici contributors

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -7322,7 +7322,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 ******************************
 
 ip-address
-10.2.0 <https://github.com/beaugunderson/ip-address>
+10.4.0 <https://github.com/beaugunderson/ip-address>
 Copyright (C) 2011 by Beau Gunderson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -9553,7 +9553,7 @@ THE SOFTWARE.
 ******************************
 
 undici
-7.28.0 <https://github.com/nodejs/undici>
+7.29.0 <https://github.com/nodejs/undici>
 MIT License
 
 Copyright (c) Matteo Collina and Undici contributors

--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -63,7 +63,7 @@
         "ssh2": "^1.16.0",
         "tar": "^7.5.19",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -11441,9 +11441,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -18629,9 +18629,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/sagemaker.series/remote/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/remote/package-lock.json
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1375,9 +1375,9 @@
       "license": "Unlicense"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -61,7 +61,7 @@
         "playwright-core": "1.59.1",
         "ssh2": "^1.16.0",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -11408,9 +11408,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -18597,9 +18597,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1328,9 +1328,9 @@
       "license": "Unlicense"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -61,7 +61,7 @@
         "playwright-core": "1.59.1",
         "ssh2": "^1.16.0",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -11408,9 +11408,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -18597,9 +18597,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/remote/package-lock.json
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1328,9 +1328,9 @@
       "license": "Unlicense"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -62,7 +62,7 @@
         "playwright-core": "1.59.1",
         "ssh2": "^1.16.0",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -11440,9 +11440,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -18628,9 +18628,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-server.series/remote/package-lock.json
+++ b/package-lock-overrides/web-server.series/remote/package-lock.json
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1375,9 +1375,9 @@
       "license": "Unlicense"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/patches/common/finding-override-axios.diff
+++ b/patches/common/finding-override-axios.diff
@@ -5,16 +5,16 @@ Remove when upstream Code-OSS updates axios to >= 1.18.0.
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-axios.diff --override 'global:axios=^1.18.0'
 @override-package: axios@^1.18.0
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -254,7 +254,8 @@
      },
      "follow-redirects": "^1.16.0",
      "uuid": "^14.0.0",
--    "ip-address": "^10.1.1"
-+    "ip-address": "^10.1.1",
+-    "ip-address": "^10.3.1"
++    "ip-address": "^10.3.1",
 +    "axios": "^1.18.0"
    },
    "repository": {

--- a/patches/common/finding-override-form-data.diff
+++ b/patches/common/finding-override-form-data.diff
@@ -4,16 +4,16 @@ Override form-data to ^4.0.6 to fix CVE-2026-12143.
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-form-data.diff --override 'global:form-data=^4.0.6'
 @override-package: form-data@^4.0.6
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -261,7 +261,8 @@
        "ws": "^7.5.11"
      },
      "@github/copilot": "^1.0.43",
--    "undici": "^7.28.0"
-+    "undici": "^7.28.0",
+-    "undici": "^7.29.0"
++    "undici": "^7.29.0",
 +    "form-data": "^4.0.6"
    },
    "repository": {

--- a/patches/common/finding-override-github-copilot.diff
+++ b/patches/common/finding-override-github-copilot.diff
@@ -5,12 +5,12 @@ Remove when upstream Code-OSS updates @github/copilot to >= 1.0.43.
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-github-copilot.diff --override 'global:@github/copilot=^1.0.43' --override 'remote/package.json@global:@github/copilot=^1.0.43'
 @override-package: @github/copilot@^1.0.43
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -258,7 +258,8 @@
-     "axios": "^1.15.2",
+     "axios": "^1.18.0",
      "chrome-remote-interface": {
        "ws": "^7.5.11"
 -    }
@@ -19,16 +19,16 @@ Index: b/package.json
    },
    "repository": {
      "type": "git",
-Index: b/remote/package.json
+Index: code-editor-src/remote/package.json
 ===================================================================
---- a/remote/package.json
-+++ b/remote/package.json
+--- code-editor-src.orig/remote/package.json
++++ code-editor-src/remote/package.json
 @@ -53,6 +53,7 @@
        "cpu-features": "0.0.0"
      },
      "uuid": "^14.0.0",
--    "ip-address": "^10.1.1"
-+    "ip-address": "^10.1.1",
+-    "ip-address": "^10.3.1"
++    "ip-address": "^10.3.1",
 +    "@github/copilot": "^1.0.43"
    }
  }

--- a/patches/common/finding-override-ip-address.diff
+++ b/patches/common/finding-override-ip-address.diff
@@ -1,10 +1,10 @@
-Override ip-address to ^10.1.1.
-Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override global:ip-address=^10.1.1 --override remote/package.json@global:ip-address=^10.1.1
-Remove when upstream Code-OSS updates ip-address to >= 10.1.1.
+Override ip-address to ^10.3.1.
+Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override global:ip-address=^10.3.1 --override remote/package.json@global:ip-address=^10.3.1
+Remove when upstream Code-OSS updates ip-address to >= 10.3.1.
 
 @generated
-@generator: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override 'global:ip-address=^10.1.1' --override 'remote/package.json@global:ip-address=^10.1.1'
-@override-package: ip-address@^10.1.1
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override 'global:ip-address=^10.3.1' --override 'remote/package.json@global:ip-address=^10.3.1'
+@override-package: ip-address@^10.3.1
 
 Index: code-editor-src/package.json
 ===================================================================
@@ -16,7 +16,7 @@ Index: code-editor-src/package.json
      "follow-redirects": "^1.16.0",
 -    "uuid": "^14.0.0"
 +    "uuid": "^14.0.0",
-+    "ip-address": "^10.1.1"
++    "ip-address": "^10.3.1"
    },
    "repository": {
      "type": "git",
@@ -30,6 +30,6 @@ Index: code-editor-src/remote/package.json
      },
 -    "uuid": "^14.0.0"
 +    "uuid": "^14.0.0",
-+    "ip-address": "^10.1.1"
++    "ip-address": "^10.3.1"
    }
  }

--- a/patches/common/finding-override-tar.diff
+++ b/patches/common/finding-override-tar.diff
@@ -4,10 +4,10 @@ Override tar to ^7.5.19.
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-tar.diff --override 'direct:tar=^7.5.19' --override 'direct-dev:tar=^7.5.19' --override 'remote/package.json@global:tar=^7.5.19'
 @override-package: tar@^7.5.19
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -140,7 +140,8 @@
      "vscode-textmate": "^9.3.2",
      "ws": "^8.21.0",
@@ -27,16 +27,16 @@ Index: b/package.json
      "tsec": "0.2.7",
      "tslib": "^2.6.3",
      "typescript": "^6.0.0-dev.20260416",
-Index: b/remote/package.json
+Index: code-editor-src/remote/package.json
 ===================================================================
---- a/remote/package.json
-+++ b/remote/package.json
+--- code-editor-src.orig/remote/package.json
++++ code-editor-src/remote/package.json
 @@ -56,6 +56,7 @@
      "uuid": "^14.0.0",
-     "ip-address": "^10.1.1",
+     "ip-address": "^10.3.1",
      "@github/copilot": "^1.0.43",
--    "undici": "^7.28.0"
-+    "undici": "^7.28.0",
+-    "undici": "^7.29.0"
++    "undici": "^7.29.0",
 +    "tar": "^7.5.19"
    }
  }

--- a/patches/common/finding-override-undici.diff
+++ b/patches/common/finding-override-undici.diff
@@ -1,19 +1,21 @@
-Override undici to ^7.28.0 to fix CVE-2026-6734, CVE-2026-9697, CVE-2026-12151.
+Override undici to ^7.29.0.
+Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-undici.diff --override direct:undici=^7.29.0 --override global:undici=^7.29.0 --override remote/package.json@global:undici=^7.29.0
+Remove when upstream Code-OSS updates undici to >= 7.29.0.
 
 @generated
-@generator: scripts/patches/apply-override.sh --patch common/finding-override-undici.diff --override 'direct:undici=^7.28.0' --override 'global:undici=^7.28.0' --override 'remote/package.json@global:undici=^7.28.0'
-@override-package: undici@^7.28.0
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-undici.diff --override 'direct:undici=^7.29.0' --override 'global:undici=^7.29.0' --override 'remote/package.json@global:undici=^7.29.0'
+@override-package: undici@^7.29.0
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -134,7 +134,7 @@
      "playwright-core": "1.59.1",
      "ssh2": "^1.16.0",
      "tas-client": "0.3.1",
 -    "undici": "^7.24.0",
-+    "undici": "^7.28.0",
++    "undici": "^7.29.0",
      "vscode-oniguruma": "1.7.0",
      "vscode-regexpp": "^3.1.0",
      "vscode-textmate": "^9.3.2",
@@ -23,20 +25,20 @@ Index: b/package.json
      },
 -    "@github/copilot": "^1.0.43"
 +    "@github/copilot": "^1.0.43",
-+    "undici": "^7.28.0"
++    "undici": "^7.29.0"
    },
    "repository": {
      "type": "git",
-Index: b/remote/package.json
+Index: code-editor-src/remote/package.json
 ===================================================================
---- a/remote/package.json
-+++ b/remote/package.json
+--- code-editor-src.orig/remote/package.json
++++ code-editor-src/remote/package.json
 @@ -55,6 +55,7 @@
      },
      "uuid": "^14.0.0",
-     "ip-address": "^10.1.1",
+     "ip-address": "^10.3.1",
 -    "@github/copilot": "^1.0.43"
 +    "@github/copilot": "^1.0.43",
-+    "undici": "^7.28.0"
++    "undici": "^7.29.0"
    }
  }

--- a/patches/common/finding-override-ws.diff
+++ b/patches/common/finding-override-ws.diff
@@ -6,10 +6,10 @@ Remove when upstream Code-OSS updates ws to >= 8.21.0.
 @override-package: ws@^8.21.0
 @override-package: ws@^7.5.11
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -138,7 +138,7 @@
      "vscode-oniguruma": "1.7.0",
      "vscode-regexpp": "^3.1.0",
@@ -22,7 +22,7 @@ Index: b/package.json
 @@ -255,7 +255,10 @@
      "follow-redirects": "^1.16.0",
      "uuid": "^14.0.0",
-     "ip-address": "^10.1.1",
+     "ip-address": "^10.3.1",
 -    "axios": "^1.18.0"
 +    "axios": "^1.18.0",
 +    "chrome-remote-interface": {
@@ -31,10 +31,10 @@ Index: b/package.json
    },
    "repository": {
      "type": "git",
-Index: b/remote/package.json
+Index: code-editor-src/remote/package.json
 ===================================================================
---- a/remote/package.json
-+++ b/remote/package.json
+--- code-editor-src.orig/remote/package.json
++++ code-editor-src/remote/package.json
 @@ -43,7 +43,7 @@
      "vscode-oniguruma": "1.7.0",
      "vscode-regexpp": "^3.1.0",


### PR DESCRIPTION
## Issue

## Description of Changes
Bumps npm dependency override versions flagged by the nightly Security Scan (Amazon Inspector, `code-editor-sagemaker-server` target) and regenerates the affected package-lock overrides + OSS attribution.

- `undici`: `^7.28.0` -> `^7.29.0`
- `ip-address`: `^10.1.1` -> `^10.3.1`

The downstream `finding-override-{axios,form-data,github-copilot,tar,ws}.diff` patches are refreshed only for diff-context drift in the shared root `overrides` block; their own override versions are unchanged.

`brace-expansion` (in `build-tools/oss-attribution/oss-attribution-generator`) is NOT included here: the `^5.0.8` -> `^5.0.9` bump on `main` is already covered by open Dependabot PR #292.

## Testing
- `./scripts/prepare-src.sh code-editor-sagemaker-server` applies the full patch series cleanly after the rebase-heal.
- Package-lock overrides regenerated for all four targets (per `scripts/update-package-locks.sh` flow) and unified OSS attribution regenerated, both inside the `code-editor-ubuntu` container.
- Verified resolved versions with `jq` in all 8 lockfiles (4 series, root + `remote/`): `undici` 7.29.0 and `ip-address` 10.4.0 (>= 10.3.1) everywhere.
- `LICENSE-THIRD-PARTY` diff is exactly the two version lines (ip-address 10.2.0 -> 10.4.0, undici 7.28.0 -> 7.29.0).

## Screenshots/Videos
N/A

## Additional Notes
Override-only change; no source/behavior changes. Patch headers keep the deterministic `@generator` metadata (`scripts/patches/apply-override.sh`) so they can be regenerated on upstream bumps.

## Backporting
The same fix is being raised as separate PRs against `1.0`, `1.1`, and `1.2`. Those PRs additionally include the `brace-expansion` `^5.0.9` build-tool bump, since Dependabot #292 targets `main` only.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
