### PR TITLE
[1.1] chore: override undici to ^7.29.0, ip-address to ^10.3.1, brace-expansion build tool to ^5.0.9

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -4707,7 +4707,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************
 
 ip-address
-10.2.0 <https://github.com/beaugunderson/ip-address>
+10.4.0 <https://github.com/beaugunderson/ip-address>
 Copyright (C) 2011 by Beau Gunderson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -6213,33 +6213,6 @@ PERFORMANCE OF THIS SOFTWARE.
 
 undici
 7.29.0 <https://github.com/nodejs/undici>
-MIT License
-
-Copyright (c) Matteo Collina and Undici contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-******************************
-
-undici
-7.28.0 <https://github.com/nodejs/undici>
 MIT License
 
 Copyright (c) Matteo Collina and Undici contributors

--- a/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/build-tools/oss-attribution/oss-attribution-generator/package.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package.json
@@ -4,6 +4,6 @@
   },
   "overrides": {
     "minimatch": "^10.2.3",
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9"
   }
 }

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -4707,7 +4707,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************
 
 ip-address
-10.2.0 <https://github.com/beaugunderson/ip-address>
+10.4.0 <https://github.com/beaugunderson/ip-address>
 Copyright (C) 2011 by Beau Gunderson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -6213,33 +6213,6 @@ PERFORMANCE OF THIS SOFTWARE.
 
 undici
 7.29.0 <https://github.com/nodejs/undici>
-MIT License
-
-Copyright (c) Matteo Collina and Undici contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-******************************
-
-undici
-7.28.0 <https://github.com/nodejs/undici>
 MIT License
 
 Copyright (c) Matteo Collina and Undici contributors

--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -49,7 +49,7 @@
         "node-pty": "^1.1.0-beta43",
         "open": "^10.1.2",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -9888,9 +9888,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -16182,9 +16182,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/sagemaker.series/remote/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/remote/package-lock.json
@@ -40,7 +40,7 @@
         "native-watchdog": "^1.4.1",
         "node-pty": "^1.1.0-beta43",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.0",
@@ -529,9 +529,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -48,7 +48,7 @@
         "node-pty": "^1.1.0-beta43",
         "open": "^10.1.2",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -9849,9 +9849,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
@@ -39,7 +39,7 @@
         "native-watchdog": "^1.4.1",
         "node-pty": "^1.1.0-beta43",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.0",
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -48,7 +48,7 @@
         "node-pty": "^1.1.0-beta43",
         "open": "^10.1.2",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -9849,9 +9849,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -16145,9 +16145,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/remote/package-lock.json
@@ -39,7 +39,7 @@
         "native-watchdog": "^1.4.1",
         "node-pty": "^1.1.0-beta43",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.0",
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -49,7 +49,7 @@
         "node-pty": "^1.1.0-beta43",
         "open": "^10.1.2",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -9901,9 +9901,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -16196,9 +16196,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-server.series/remote/package-lock.json
+++ b/package-lock-overrides/web-server.series/remote/package-lock.json
@@ -40,7 +40,7 @@
         "native-watchdog": "^1.4.1",
         "node-pty": "^1.1.0-beta43",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.0",
@@ -529,9 +529,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/patches/common/finding-override-ip-address.diff
+++ b/patches/common/finding-override-ip-address.diff
@@ -1,10 +1,10 @@
-Override ip-address to ^10.1.1.
-Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override global:ip-address=^10.1.1 --override remote/package.json@global:ip-address=^10.1.1
-Remove when upstream Code-OSS updates ip-address to >= 10.1.1.
+Override ip-address to ^10.3.1.
+Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override global:ip-address=^10.3.1 --override remote/package.json@global:ip-address=^10.3.1
+Remove when upstream Code-OSS updates ip-address to >= 10.3.1.
 
 @generated
-@generator: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override 'global:ip-address=^10.1.1' --override 'remote/package.json@global:ip-address=^10.1.1'
-@override-package: ip-address@^10.1.1
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override 'global:ip-address=^10.3.1' --override 'remote/package.json@global:ip-address=^10.3.1'
+@override-package: ip-address@^10.3.1
 
 Index: b/package.json
 ===================================================================
@@ -16,7 +16,7 @@ Index: b/package.json
      "follow-redirects": "^1.16.0",
 -    "uuid": "^14.0.0"
 +    "uuid": "^14.0.0",
-+    "ip-address": "^10.1.1"
++    "ip-address": "^10.3.1"
    },
    "repository": {
      "type": "git",
@@ -30,6 +30,6 @@ Index: b/remote/package.json
      "follow-redirects": "^1.16.0",
 -    "uuid": "^14.0.0"
 +    "uuid": "^14.0.0",
-+    "ip-address": "^10.1.1"
++    "ip-address": "^10.3.1"
    }
  }

--- a/patches/common/finding-override-shell-quote.diff
+++ b/patches/common/finding-override-shell-quote.diff
@@ -10,12 +10,12 @@ Index: b/package.json
 ===================================================================
 --- a/package.json
 +++ b/package.json
-@@ -243,7 +243,8 @@
+@@ -241,7 +241,8 @@
      "picomatch": "^2.3.2",
      "follow-redirects": "^1.16.0",
      "uuid": "^14.0.0",
--    "ip-address": "^10.1.1"
-+    "ip-address": "^10.1.1",
+-    "ip-address": "^10.3.1"
++    "ip-address": "^10.3.1",
 +    "shell-quote": "^1.8.4"
    },
    "repository": {

--- a/patches/common/finding-override-tar.diff
+++ b/patches/common/finding-override-tar.diff
@@ -18,9 +18,9 @@ Index: b/package.json
      "tsec": "0.2.7",
      "tslib": "^2.6.3",
 @@ -246,7 +246,8 @@
-     "ip-address": "^10.1.1",
+     "ip-address": "^10.3.1",
      "shell-quote": "^1.8.4",
-     "undici": "^7.28.0",
+     "undici": "^7.29.0",
 -    "ws": "^7.5.11"
 +    "ws": "^7.5.11",
 +    "tar": "^7.5.19"

--- a/patches/common/finding-override-undici.diff
+++ b/patches/common/finding-override-undici.diff
@@ -1,8 +1,10 @@
-Override undici to ^7.28.0 to fix CVE-2026-6734, CVE-2026-9697, CVE-2026-12151.
+Override undici to ^7.29.0.
+Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-undici.diff --override direct:undici=^7.29.0 --override global:undici=^7.29.0 --override remote/package.json@direct:undici=^7.29.0 --override remote/package.json@global:undici=^7.29.0
+Remove when upstream Code-OSS updates undici to >= 7.29.0.
 
 @generated
-@generator: scripts/patches/apply-override.sh --patch common/finding-override-undici.diff --override 'direct:undici=^7.28.0' --override 'global:undici=^7.28.0' --override 'remote/package.json@direct:undici=^7.28.0' --override 'remote/package.json@global:undici=^7.28.0'
-@override-package: undici@^7.28.0
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-undici.diff --override 'direct:undici=^7.29.0' --override 'global:undici=^7.29.0' --override 'remote/package.json@direct:undici=^7.29.0' --override 'remote/package.json@global:undici=^7.29.0'
+@override-package: undici@^7.29.0
 
 Index: b/package.json
 ===================================================================
@@ -13,17 +15,17 @@ Index: b/package.json
      "open": "^10.1.2",
      "tas-client": "0.3.1",
 -    "undici": "^7.24.0",
-+    "undici": "^7.28.0",
++    "undici": "^7.29.0",
      "v8-inspect-profiler": "^0.1.1",
      "vscode-oniguruma": "1.7.0",
      "vscode-regexpp": "^3.1.0",
 @@ -244,7 +244,8 @@
      "follow-redirects": "^1.16.0",
      "uuid": "^14.0.0",
-     "ip-address": "^10.1.1",
+     "ip-address": "^10.3.1",
 -    "shell-quote": "^1.8.4"
 +    "shell-quote": "^1.8.4",
-+    "undici": "^7.28.0"
++    "undici": "^7.29.0"
    },
    "repository": {
      "type": "git",
@@ -36,7 +38,7 @@ Index: b/remote/package.json
      "node-pty": "^1.1.0-beta43",
      "tas-client": "0.3.1",
 -    "undici": "^7.24.0",
-+    "undici": "^7.28.0",
++    "undici": "^7.29.0",
      "vscode-oniguruma": "1.7.0",
      "vscode-regexpp": "^3.1.0",
      "vscode-textmate": "^9.3.0",
@@ -44,8 +46,8 @@ Index: b/remote/package.json
      "picomatch": "^2.3.2",
      "follow-redirects": "^1.16.0",
      "uuid": "^14.0.0",
--    "ip-address": "^10.1.1"
-+    "ip-address": "^10.1.1",
-+    "undici": "^7.28.0"
+-    "ip-address": "^10.3.1"
++    "ip-address": "^10.3.1",
++    "undici": "^7.29.0"
    }
  }

--- a/patches/common/finding-override-ws.diff
+++ b/patches/common/finding-override-ws.diff
@@ -10,10 +10,10 @@ Index: b/package.json
 +++ b/package.json
 @@ -245,7 +245,8 @@
      "uuid": "^14.0.0",
-     "ip-address": "^10.1.1",
+     "ip-address": "^10.3.1",
      "shell-quote": "^1.8.4",
--    "undici": "^7.28.0"
-+    "undici": "^7.28.0",
+-    "undici": "^7.29.0"
++    "undici": "^7.29.0",
 +    "ws": "^7.5.11"
    },
    "repository": {


### PR DESCRIPTION
## Issue

## Description of Changes
Bumps npm dependency override versions flagged by the nightly Security Scan (Amazon Inspector, `code-editor-sagemaker-server` target) and regenerates the affected package-lock overrides + OSS attribution.

- `undici`: `^7.28.0` -> `^7.29.0`
- `ip-address`: `^10.1.1` -> `^10.3.1`
- `brace-expansion` (in `build-tools/oss-attribution/oss-attribution-generator`): `^5.0.8` -> `^5.0.9`

The downstream `finding-override-{shell-quote,tar,ws}.diff` patches are refreshed only for diff-context drift in the shared root `overrides` block; their own override versions are unchanged. The regenerated `LICENSE-THIRD-PARTY` also drops a stale duplicate undici 7.28.0 entry that was present in the committed baseline.

Note: on `main` the `brace-expansion` build-tool bump is covered by Dependabot PR #292; that PR targets `main` only, so this branch includes the bump directly.

## Testing
- `./scripts/prepare-src.sh` applies the full patch series cleanly for both leaf targets (`code-editor-sagemaker-server` and `code-editor-web-embedded-with-terminal`) after the rebase-heal.
- `./scripts/update-package-locks.sh` regenerated lockfiles + unified OSS attribution for all four targets with exit 0, inside the `code-editor-ubuntu` container.
- Verified resolved versions with `jq` in all 8 lockfiles (4 series, root + `remote/`): `undici` 7.29.0 and `ip-address` 10.4.0 (>= 10.3.1) everywhere; `brace-expansion` resolves to 5.0.9 in the build-tool lockfile.

## Screenshots/Videos
N/A

## Additional Notes
Override-only change; no source/behavior changes. Patch headers keep the deterministic `@generator` metadata (`scripts/patches/apply-override.sh`) so they can be regenerated on upstream bumps.

## Backporting
Same fix raised separately against `main` (#293), `1.0` (#294), and `1.2`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
