### PR TITLE
[1.2] chore: override undici to ^7.29.0, ip-address to ^10.3.1, brace-expansion build tool to ^5.0.9

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -7322,7 +7322,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 ******************************
 
 ip-address
-10.2.0 <https://github.com/beaugunderson/ip-address>
+10.4.0 <https://github.com/beaugunderson/ip-address>
 Copyright (C) 2011 by Beau Gunderson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -9492,7 +9492,7 @@ THE SOFTWARE.
 ******************************
 
 undici
-7.28.0 <https://github.com/nodejs/undici>
+7.29.0 <https://github.com/nodejs/undici>
 MIT License
 
 Copyright (c) Matteo Collina and Undici contributors

--- a/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package-lock.json
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/build-tools/oss-attribution/oss-attribution-generator/package.json
+++ b/build-tools/oss-attribution/oss-attribution-generator/package.json
@@ -4,6 +4,6 @@
   },
   "overrides": {
     "minimatch": "^10.2.3",
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9"
   }
 }

--- a/overrides/LICENSE-THIRD-PARTY
+++ b/overrides/LICENSE-THIRD-PARTY
@@ -7322,7 +7322,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 ******************************
 
 ip-address
-10.2.0 <https://github.com/beaugunderson/ip-address>
+10.4.0 <https://github.com/beaugunderson/ip-address>
 Copyright (C) 2011 by Beau Gunderson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -9492,7 +9492,7 @@ THE SOFTWARE.
 ******************************
 
 undici
-7.28.0 <https://github.com/nodejs/undici>
+7.29.0 <https://github.com/nodejs/undici>
 MIT License
 
 Copyright (c) Matteo Collina and Undici contributors

--- a/package-lock-overrides/sagemaker.series/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/package-lock.json
@@ -63,7 +63,7 @@
         "ssh2": "^1.16.0",
         "tar": "^7.5.19",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -11441,9 +11441,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -18629,9 +18629,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/sagemaker.series/remote/package-lock.json
+++ b/package-lock-overrides/sagemaker.series/remote/package-lock.json
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1375,9 +1375,9 @@
       "license": "Unlicense"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/package-lock.json
@@ -62,7 +62,7 @@
         "ssh2": "^1.16.0",
         "tar": "^7.5.19",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -11409,9 +11409,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -18598,9 +18598,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded-with-terminal.series/remote/package-lock.json
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1328,9 +1328,9 @@
       "license": "Unlicense"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded.series/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/package-lock.json
@@ -62,7 +62,7 @@
         "ssh2": "^1.16.0",
         "tar": "^7.5.19",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -11409,9 +11409,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -18598,9 +18598,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-embedded.series/remote/package-lock.json
+++ b/package-lock-overrides/web-embedded.series/remote/package-lock.json
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1328,9 +1328,9 @@
       "license": "Unlicense"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-server.series/package-lock.json
+++ b/package-lock-overrides/web-server.series/package-lock.json
@@ -63,7 +63,7 @@
         "ssh2": "^1.16.0",
         "tar": "^7.5.19",
         "tas-client": "0.3.1",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "^9.3.2",
@@ -11441,9 +11441,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -18629,9 +18629,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock-overrides/web-server.series/remote/package-lock.json
+++ b/package-lock-overrides/web-server.series/remote/package-lock.json
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1375,9 +1375,9 @@
       "license": "Unlicense"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/patches/common/copilot-restrict-debug-override-urls-to-user-scope.diff
+++ b/patches/common/copilot-restrict-debug-override-urls-to-user-scope.diff
@@ -12,10 +12,10 @@ Remove when Code-OSS is updated to >= 1.128.1.
 @backported: https://github.com/microsoft/vscode/commit/f05bcd1aa29cff28a62fe137b4a16fec9393f31b
 @finding-id: CVE-2026-47282 GHSA-wr9x-42j2-jvh3
 
-Index: b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
+Index: code-editor-src/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
 ===================================================================
---- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
-+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
+--- code-editor-src.orig/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
++++ code-editor-src/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
 @@ -15,7 +15,8 @@ import {
  	getOptionalConfigDefaultForKey,
  	ICompletionsConfigProvider,
@@ -65,10 +65,10 @@ Index: b/extensions/copilot/src/extension/completions-core/vscode-node/extension
  	// Dumps config settings defined in the extension json
  	override dumpForTelemetry(): { [key: string]: string } {
  		return {};
-Index: b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
+Index: code-editor-src/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
 ===================================================================
---- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
-+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
+--- code-editor-src.orig/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
++++ code-editor-src/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
 @@ -75,6 +75,21 @@ export const ConfigKey = {
  	UseSplitContextPrompt: 'internal.useSplitContextPrompt',
  };
@@ -91,10 +91,10 @@ Index: b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/c
  export type ConfigKeyType = string;
  
  // How to determine where to terminate the completion to the current block.
-Index: b/extensions/copilot/src/platform/configuration/common/configurationService.ts
+Index: code-editor-src/extensions/copilot/src/platform/configuration/common/configurationService.ts
 ===================================================================
---- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
-+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
+--- code-editor-src.orig/extensions/copilot/src/platform/configuration/common/configurationService.ts
++++ code-editor-src/extensions/copilot/src/platform/configuration/common/configurationService.ts
 @@ -375,6 +375,12 @@ export const enum ConfigType {
  export interface ConfigOptions {
  	readonly oldKey?: string;
@@ -119,10 +119,10 @@ Index: b/extensions/copilot/src/platform/configuration/common/configurationServi
  		export const DebugUseNodeFetchFetcher = defineSetting('advanced.debug.useNodeFetchFetcher', ConfigType.Simple, true);
  		export const DebugUseNodeFetcher = defineSetting('advanced.debug.useNodeFetcher', ConfigType.Simple, false);
  		export const DebugUseElectronFetcher = defineSetting('advanced.debug.useElectronFetcher', ConfigType.Simple, true);
-Index: b/extensions/copilot/src/platform/configuration/vscode/configurationServiceImpl.ts
+Index: code-editor-src/extensions/copilot/src/platform/configuration/vscode/configurationServiceImpl.ts
 ===================================================================
---- a/extensions/copilot/src/platform/configuration/vscode/configurationServiceImpl.ts
-+++ b/extensions/copilot/src/platform/configuration/vscode/configurationServiceImpl.ts
+--- code-editor-src.orig/extensions/copilot/src/platform/configuration/vscode/configurationServiceImpl.ts
++++ code-editor-src/extensions/copilot/src/platform/configuration/vscode/configurationServiceImpl.ts
 @@ -57,7 +57,9 @@ export class ConfigurationServiceImpl ex
  		const config = scope === undefined ? this.config : vscode.workspace.getConfiguration(CopilotConfigPrefix, scope);
  

--- a/patches/common/finding-override-anthropic-sdk.diff
+++ b/patches/common/finding-override-anthropic-sdk.diff
@@ -5,10 +5,10 @@ Remove when upstream Code-OSS updates @anthropic-ai/sdk to >= 0.91.1.
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-anthropic-sdk.diff --override 'direct:@anthropic-ai/sdk=^0.91.1'
 @override-package: @anthropic-ai/sdk@^0.91.1
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -82,7 +82,7 @@
      "install-latest-component-explorer": "npm install @vscode/component-explorer@next @vscode/component-explorer-cli@next && cd build/rspack && npm install @vscode/component-explorer-webpack-plugin@next @vscode/component-explorer@next && cd ../vite && npm install @vscode/component-explorer-vite-plugin@next @vscode/component-explorer@next"
    },

--- a/patches/common/finding-override-axios.diff
+++ b/patches/common/finding-override-axios.diff
@@ -5,16 +5,16 @@ Remove when upstream Code-OSS updates axios to >= 1.18.0.
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-axios.diff --override 'global:axios=^1.18.0'
 @override-package: axios@^1.18.0
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -254,7 +254,8 @@
      },
      "follow-redirects": "^1.16.0",
      "uuid": "^14.0.0",
--    "ip-address": "^10.1.1"
-+    "ip-address": "^10.1.1",
+-    "ip-address": "^10.3.1"
++    "ip-address": "^10.3.1",
 +    "axios": "^1.18.0"
    },
    "repository": {

--- a/patches/common/finding-override-form-data.diff
+++ b/patches/common/finding-override-form-data.diff
@@ -4,16 +4,16 @@ Override form-data to ^4.0.6 to fix CVE-2026-12143.
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-form-data.diff --override 'global:form-data=^4.0.6'
 @override-package: form-data@^4.0.6
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -261,7 +261,8 @@
        "ws": "^7.5.11"
      },
      "@github/copilot": "^1.0.43",
--    "undici": "^7.28.0"
-+    "undici": "^7.28.0",
+-    "undici": "^7.29.0"
++    "undici": "^7.29.0",
 +    "form-data": "^4.0.6"
    },
    "repository": {

--- a/patches/common/finding-override-github-copilot.diff
+++ b/patches/common/finding-override-github-copilot.diff
@@ -5,12 +5,12 @@ Remove when upstream Code-OSS updates @github/copilot to >= 1.0.43.
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-github-copilot.diff --override 'global:@github/copilot=^1.0.43' --override 'remote/package.json@global:@github/copilot=^1.0.43'
 @override-package: @github/copilot@^1.0.43
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -258,7 +258,8 @@
-     "axios": "^1.15.2",
+     "axios": "^1.18.0",
      "chrome-remote-interface": {
        "ws": "^7.5.11"
 -    }
@@ -19,16 +19,16 @@ Index: b/package.json
    },
    "repository": {
      "type": "git",
-Index: b/remote/package.json
+Index: code-editor-src/remote/package.json
 ===================================================================
---- a/remote/package.json
-+++ b/remote/package.json
+--- code-editor-src.orig/remote/package.json
++++ code-editor-src/remote/package.json
 @@ -53,6 +53,7 @@
        "cpu-features": "0.0.0"
      },
      "uuid": "^14.0.0",
--    "ip-address": "^10.1.1"
-+    "ip-address": "^10.1.1",
+-    "ip-address": "^10.3.1"
++    "ip-address": "^10.3.1",
 +    "@github/copilot": "^1.0.43"
    }
  }

--- a/patches/common/finding-override-ip-address.diff
+++ b/patches/common/finding-override-ip-address.diff
@@ -1,10 +1,10 @@
-Override ip-address to ^10.1.1.
-Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override global:ip-address=^10.1.1 --override remote/package.json@global:ip-address=^10.1.1
-Remove when upstream Code-OSS updates ip-address to >= 10.1.1.
+Override ip-address to ^10.3.1.
+Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override global:ip-address=^10.3.1 --override remote/package.json@global:ip-address=^10.3.1
+Remove when upstream Code-OSS updates ip-address to >= 10.3.1.
 
 @generated
-@generator: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override 'global:ip-address=^10.1.1' --override 'remote/package.json@global:ip-address=^10.1.1'
-@override-package: ip-address@^10.1.1
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-ip-address.diff --override 'global:ip-address=^10.3.1' --override 'remote/package.json@global:ip-address=^10.3.1'
+@override-package: ip-address@^10.3.1
 
 Index: code-editor-src/package.json
 ===================================================================
@@ -16,7 +16,7 @@ Index: code-editor-src/package.json
      "follow-redirects": "^1.16.0",
 -    "uuid": "^14.0.0"
 +    "uuid": "^14.0.0",
-+    "ip-address": "^10.1.1"
++    "ip-address": "^10.3.1"
    },
    "repository": {
      "type": "git",
@@ -30,6 +30,6 @@ Index: code-editor-src/remote/package.json
      },
 -    "uuid": "^14.0.0"
 +    "uuid": "^14.0.0",
-+    "ip-address": "^10.1.1"
++    "ip-address": "^10.3.1"
    }
  }

--- a/patches/common/finding-override-shell-quote.diff
+++ b/patches/common/finding-override-shell-quote.diff
@@ -5,10 +5,10 @@ Remove when upstream Code-OSS updates shell-quote to >= 1.9.0.
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-shell-quote.diff --override 'global:shell-quote=^1.9.0' --override 'remote/package.json@global:shell-quote=^1.9.0'
 @override-package: shell-quote@^1.9.0
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -246,6 +246,7 @@
      "yaserver": "^0.4.0"
    },
@@ -17,10 +17,10 @@ Index: b/package.json
      "postcss": "^8.4.31",
      "node-gyp-build": "4.8.1",
      "serialize-javascript": "^7.0.3",
-Index: b/remote/package.json
+Index: code-editor-src/remote/package.json
 ===================================================================
---- a/remote/package.json
-+++ b/remote/package.json
+--- code-editor-src.orig/remote/package.json
++++ code-editor-src/remote/package.json
 @@ -48,6 +48,7 @@
      "yazl": "^2.4.3"
    },

--- a/patches/common/finding-override-tar.diff
+++ b/patches/common/finding-override-tar.diff
@@ -4,10 +4,10 @@ Override tar to ^7.5.19.
 @generator: scripts/patches/apply-override.sh --patch common/finding-override-tar.diff --override 'direct:tar=^7.5.19' --override 'direct-dev:tar=^7.5.19' --override 'remote/package.json@global:tar=^7.5.19'
 @override-package: tar@^7.5.19
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -140,7 +140,8 @@
      "vscode-textmate": "^9.3.2",
      "ws": "^8.21.0",
@@ -27,16 +27,16 @@ Index: b/package.json
      "tsec": "0.2.7",
      "tslib": "^2.6.3",
      "typescript": "^6.0.0-dev.20260416",
-Index: b/remote/package.json
+Index: code-editor-src/remote/package.json
 ===================================================================
---- a/remote/package.json
-+++ b/remote/package.json
+--- code-editor-src.orig/remote/package.json
++++ code-editor-src/remote/package.json
 @@ -56,6 +56,7 @@
      "uuid": "^14.0.0",
-     "ip-address": "^10.1.1",
+     "ip-address": "^10.3.1",
      "@github/copilot": "^1.0.43",
--    "undici": "^7.28.0"
-+    "undici": "^7.28.0",
+-    "undici": "^7.29.0"
++    "undici": "^7.29.0",
 +    "tar": "^7.5.19"
    }
  }

--- a/patches/common/finding-override-undici.diff
+++ b/patches/common/finding-override-undici.diff
@@ -1,19 +1,21 @@
-Override undici to ^7.28.0 to fix CVE-2026-6734, CVE-2026-9697, CVE-2026-12151.
+Override undici to ^7.29.0.
+Regenerate: scripts/patches/apply-override.sh --patch common/finding-override-undici.diff --override direct:undici=^7.29.0 --override global:undici=^7.29.0 --override remote/package.json@global:undici=^7.29.0
+Remove when upstream Code-OSS updates undici to >= 7.29.0.
 
 @generated
-@generator: scripts/patches/apply-override.sh --patch common/finding-override-undici.diff --override 'direct:undici=^7.28.0' --override 'global:undici=^7.28.0' --override 'remote/package.json@global:undici=^7.28.0'
-@override-package: undici@^7.28.0
+@generator: scripts/patches/apply-override.sh --patch common/finding-override-undici.diff --override 'direct:undici=^7.29.0' --override 'global:undici=^7.29.0' --override 'remote/package.json@global:undici=^7.29.0'
+@override-package: undici@^7.29.0
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -134,7 +134,7 @@
      "playwright-core": "1.59.1",
      "ssh2": "^1.16.0",
      "tas-client": "0.3.1",
 -    "undici": "^7.24.0",
-+    "undici": "^7.28.0",
++    "undici": "^7.29.0",
      "vscode-oniguruma": "1.7.0",
      "vscode-regexpp": "^3.1.0",
      "vscode-textmate": "^9.3.2",
@@ -23,20 +25,20 @@ Index: b/package.json
      },
 -    "@github/copilot": "^1.0.43"
 +    "@github/copilot": "^1.0.43",
-+    "undici": "^7.28.0"
++    "undici": "^7.29.0"
    },
    "repository": {
      "type": "git",
-Index: b/remote/package.json
+Index: code-editor-src/remote/package.json
 ===================================================================
---- a/remote/package.json
-+++ b/remote/package.json
+--- code-editor-src.orig/remote/package.json
++++ code-editor-src/remote/package.json
 @@ -55,6 +55,7 @@
      },
      "uuid": "^14.0.0",
-     "ip-address": "^10.1.1",
+     "ip-address": "^10.3.1",
 -    "@github/copilot": "^1.0.43"
 +    "@github/copilot": "^1.0.43",
-+    "undici": "^7.28.0"
++    "undici": "^7.29.0"
    }
  }

--- a/patches/common/finding-override-ws.diff
+++ b/patches/common/finding-override-ws.diff
@@ -6,10 +6,10 @@ Remove when upstream Code-OSS updates ws to >= 8.21.0.
 @override-package: ws@^8.21.0
 @override-package: ws@^7.5.11
 
-Index: b/package.json
+Index: code-editor-src/package.json
 ===================================================================
---- a/package.json
-+++ b/package.json
+--- code-editor-src.orig/package.json
++++ code-editor-src/package.json
 @@ -138,7 +138,7 @@
      "vscode-oniguruma": "1.7.0",
      "vscode-regexpp": "^3.1.0",
@@ -22,7 +22,7 @@ Index: b/package.json
 @@ -255,7 +255,10 @@
      "follow-redirects": "^1.16.0",
      "uuid": "^14.0.0",
-     "ip-address": "^10.1.1",
+     "ip-address": "^10.3.1",
 -    "axios": "^1.18.0"
 +    "axios": "^1.18.0",
 +    "chrome-remote-interface": {
@@ -31,10 +31,10 @@ Index: b/package.json
    },
    "repository": {
      "type": "git",
-Index: b/remote/package.json
+Index: code-editor-src/remote/package.json
 ===================================================================
---- a/remote/package.json
-+++ b/remote/package.json
+--- code-editor-src.orig/remote/package.json
++++ code-editor-src/remote/package.json
 @@ -43,7 +43,7 @@
      "vscode-oniguruma": "1.7.0",
      "vscode-regexpp": "^3.1.0",

--- a/patches/common/ghsa-credential-provider-host-match.diff
+++ b/patches/common/ghsa-credential-provider-host-match.diff
@@ -6,10 +6,10 @@ Bug: GHSA credential provider regex host match
 Change GitHub credential provider from regex-based host matching to
 strict hostname equality check to prevent credential leakage to
 attacker-controlled domains matching the pattern (e.g. notgithub.com).
-Index: b/extensions/github/src/credentialProvider.ts
+Index: code-editor-src/extensions/github/src/credentialProvider.ts
 ===================================================================
---- a/extensions/github/src/credentialProvider.ts
-+++ b/extensions/github/src/credentialProvider.ts
+--- code-editor-src.orig/extensions/github/src/credentialProvider.ts
++++ code-editor-src/extensions/github/src/credentialProvider.ts
 @@ -12,7 +12,8 @@ const EmptyDisposable: Disposable = { di
  class GitHubCredentialProvider implements CredentialsProvider {
  

--- a/patches/common/ghsa-remote-hosts-loopback.diff
+++ b/patches/common/ghsa-remote-hosts-loopback.diff
@@ -7,10 +7,10 @@ Add isLoopbackHost function to validate whether a direct host:port remote
 authority targets the local loopback interface. This enables prompting users
 before connecting to non-loopback remote hosts that could originate from
 untrusted workspace files.
-Index: b/src/vs/platform/remote/common/remoteHosts.ts
+Index: code-editor-src/src/vs/platform/remote/common/remoteHosts.ts
 ===================================================================
---- a/src/vs/platform/remote/common/remoteHosts.ts
-+++ b/src/vs/platform/remote/common/remoteHosts.ts
+--- code-editor-src.orig/src/vs/platform/remote/common/remoteHosts.ts
++++ code-editor-src/src/vs/platform/remote/common/remoteHosts.ts
 @@ -87,3 +87,20 @@ function parseAuthority(authority: strin
  	// doesn't contain a port
  	return { host: authority, port: undefined };

--- a/patches/common/ghsa-snippets-path-traversal.diff
+++ b/patches/common/ghsa-snippets-path-traversal.diff
@@ -6,10 +6,10 @@ Bug: GHSA profile snippets path traversal
 Add path traversal protection to snippet import. Validates that resolved
 snippet resource URIs remain within the snippetsHome directory, preventing
 an attacker-crafted profile from writing files outside the profile folder.
-Index: b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+Index: code-editor-src/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
 ===================================================================
---- a/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
-+++ b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+--- code-editor-src.orig/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
++++ code-editor-src/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
 @@ -6,10 +6,12 @@
  import { VSBuffer } from '../../../../base/common/buffer.js';
  import { IStringDictionary } from '../../../../base/common/collections.js';
@@ -78,10 +78,10 @@ Index: b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
  			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
  		}
  	}
-Index: b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+Index: code-editor-src/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
 ===================================================================
---- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
-+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+--- code-editor-src.orig/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
++++ code-editor-src/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
 @@ -85,7 +85,7 @@ export class UserDataProfileInitializer
  				promises.push(this.initialize(new McpResourceInitializer(this.userDataProfileService, this.fileService, this.logService), profileTemplate.mcp, ProfileResourceType.Mcp));
  			}

--- a/patches/web-server/webview.diff
+++ b/patches/web-server/webview.diff
@@ -93,9 +93,10 @@ Index: code-editor-src/src/vs/workbench/services/extensions/worker/webWorkerExte
 -	const parentOrigin = searchParams.get('parentOrigin') || window.origin;
 +	let parentOrigin = window.origin;
  	const salt = searchParams.get('salt');
-
+ 
  	(async function () {
 @@ -25,6 +25,8 @@
+ 			// validation not requested
  			return start();
  		}
 +


### PR DESCRIPTION
## Issue

## Description of Changes
Bumps npm dependency override versions flagged by the nightly Security Scan (Amazon Inspector, `code-editor-sagemaker-server` target) and regenerates the affected package-lock overrides + OSS attribution.

- `undici`: `^7.28.0` -> `^7.29.0`
- `ip-address`: `^10.1.1` -> `^10.3.1`
- `brace-expansion` (in `build-tools/oss-attribution/oss-attribution-generator`): `^5.0.8` -> `^5.0.9`

The downstream `finding-override-{axios,ws,github-copilot,form-data,tar,anthropic-sdk,shell-quote}.diff` patches and a few later quilt-managed patches are refreshed only for diff-context drift in the shared root `overrides` block (hunk offsets and header style); their own override versions and code changes are unchanged.

Note: on `main` the `brace-expansion` build-tool bump is covered by Dependabot PR #292; that PR targets `main` only, so this branch includes the bump directly.

## Testing
- `./scripts/prepare-src.sh` applies the full patch series cleanly for both leaf targets (`code-editor-sagemaker-server` and `code-editor-web-embedded-with-terminal`) after the rebase-heal.
- `./scripts/update-package-locks.sh` regenerated lockfiles + unified OSS attribution for all four targets with exit 0, inside the `code-editor-ubuntu` container.
- Verified resolved versions with `jq` in all 8 lockfiles (4 series, root + `remote/`): `undici` 7.29.0 and `ip-address` 10.4.0 (>= 10.3.1) everywhere; `brace-expansion` resolves to 5.0.9 in the build-tool lockfile.
- `LICENSE-THIRD-PARTY` diff is exactly the two version lines (ip-address 10.2.0 -> 10.4.0, undici 7.28.0 -> 7.29.0).

## Screenshots/Videos
N/A

## Additional Notes
Override-only change; no source/behavior changes. Patch headers keep the deterministic `@generator` metadata (`scripts/patches/apply-override.sh`) so they can be regenerated on upstream bumps.

## Backporting
Same fix raised separately against `main` (#293), `1.0` (#294), and `1.1` (#295).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
