### PR TITLE
ci: extend Dependabot coverage to release branches 1.0, 1.1, 1.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/build-tools/oss-attribution/oss-attribution-generator"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/build-tools/oss-attribution/oss-attribution-generator"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.0"
+  - package-ecosystem: "npm"
+    directory: "/build-tools/oss-attribution/oss-attribution-generator"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.1"
+  - package-ecosystem: "npm"
+    directory: "/build-tools/oss-attribution/oss-attribution-generator"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.2"


### PR DESCRIPTION
## Issue

## Description of Changes
Adds `.github/dependabot.yml` with `target-branch` entries so Dependabot version updates cover the active release branches `1.0`, `1.1`, and `1.2` in addition to `main`.

Dependabot only evaluates the `dependabot.yml` on the repository's default branch, so per-branch coverage must be declared there via `target-branch` entries; a config on the release branches themselves would be ignored. This gap showed up with the recent brace-expansion security fix: Dependabot PR #292 bumped `build-tools/oss-attribution/oss-attribution-generator/package.json` on `main` only, and the same vulnerable dependency had to be manually bumped on `1.0`, `1.1`, and `1.2`.

The new entries mirror the existing npm update configuration (directory `/build-tools/oss-attribution/oss-attribution-generator`, weekly schedule), once per release branch. That directory (with `package.json` and `package-lock.json`) was verified to exist and be identical on `origin/1.0`, `origin/1.1`, and `origin/1.2`; it is the only npm manifest outside `third-party-src` on those branches, so no other ecosystems or directories were added.

## Testing
- Validated YAML syntax with `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`.
- Verified `build-tools/oss-attribution/oss-attribution-generator/package.json` exists on `origin/1.0`, `origin/1.1`, and `origin/1.2` via `git ls-tree`.
- Verified none of the release branches carry their own `.github/dependabot.yml` (not that it would matter; only the default-branch config is read).

## Screenshots/Videos
N/A

## Additional Notes
Dependabot security updates (as opposed to scheduled version updates) always target only the default branch; the `target-branch` entries ensure the release branches at least receive scheduled version-update PRs for this directory.

## Backporting
Not required. Dependabot reads this configuration from the default branch only, so this change on `main` is sufficient to cover `1.0`, `1.1`, and `1.2`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
