### PR TITLE
Add --target flag to update-package-locks.sh

### DIFF
--- a/scripts/update-package-locks.sh
+++ b/scripts/update-package-locks.sh
@@ -2,9 +2,49 @@
 
 set -e
 
-TARGETS=(code-editor-server code-editor-sagemaker-server code-editor-web-embedded code-editor-web-embedded-with-terminal)
+ALL_TARGETS=(code-editor-server code-editor-sagemaker-server code-editor-web-embedded code-editor-web-embedded-with-terminal)
 
-echo "Updating package-lock overrides for all targets..."
+# Parse command line arguments
+SELECTED_TARGETS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      [[ $# -ge 2 ]] || { echo "Error: --target requires a value" >&2; exit 1; }
+      if [[ ! -f "configuration/$2.json" ]]; then
+        echo "Error: Unknown target: $2" >&2
+        echo "Available targets: ${ALL_TARGETS[*]}" >&2
+        exit 1
+      fi
+      SELECTED_TARGETS+=("$2")
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: $0 [--target <target>]..." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ${#SELECTED_TARGETS[@]} -gt 0 ]]; then
+  TARGETS=("${SELECTED_TARGETS[@]}")
+else
+  TARGETS=("${ALL_TARGETS[@]}")
+fi
+
+# Unified OSS attribution needs all targets prepared
+RUN_ATTRIBUTION=true
+for target in "${ALL_TARGETS[@]}"; do
+  found=false
+  for selected in "${TARGETS[@]}"; do
+    [[ "$selected" == "$target" ]] && found=true
+  done
+  if [[ "$found" == false ]]; then
+    RUN_ATTRIBUTION=false
+  fi
+done
+
+echo "Updating package-lock overrides for targets: ${TARGETS[*]}"
 
 # Clean up any existing prepared source directories
 for target in "${TARGETS[@]}"; do
@@ -56,13 +96,19 @@ for target in "${TARGETS[@]}"; do
   echo "=== COMPLETED TARGET: $target ==="
 done
 
-# Generate unified OSS attribution
-echo ""
-echo "Generating unified OSS attribution..."
-./scripts/generate-oss-attribution.sh --command generate_unified_oss_attribution
+# Generate unified OSS attribution (requires all targets prepared)
+if [[ "$RUN_ATTRIBUTION" == true ]]; then
+  echo ""
+  echo "Generating unified OSS attribution..."
+  ./scripts/generate-oss-attribution.sh --command generate_unified_oss_attribution
 
-# Copy LICENSE-THIRD-PARTY to root directory
-cp overrides/LICENSE-THIRD-PARTY LICENSE-THIRD-PARTY
+  # Copy LICENSE-THIRD-PARTY to root directory
+  cp overrides/LICENSE-THIRD-PARTY LICENSE-THIRD-PARTY
+else
+  echo ""
+  echo "Skipping unified OSS attribution: it requires all targets to be prepared."
+  echo "Run this script without --target, or run ./scripts/generate-oss-attribution.sh --command generate_unified_oss_attribution separately."
+fi
 
 # Clean up prepared source directories
 echo "Cleaning up prepared source directories..."


### PR DESCRIPTION
## Issue
<!-- Please add just the issue number (e.g., D316398873) - do not paste the full link -->



## Description of Changes
Adds a repeatable `--target <target>` flag to `scripts/update-package-locks.sh` so a single build target's package-lock overrides can be regenerated without running `prepare-src` + `npm install` for all four targets.

- No arguments: unchanged behavior (all four targets, then unified OSS attribution).
- `--target <t>` (repeatable): processes only the named target(s). Target names are validated against `configuration/*.json`; unknown names fail fast with the list of valid targets.
- The unified OSS attribution step requires all four prepared source trees, so it is skipped when not all targets are processed. A note tells the user to run the full script or `generate-oss-attribution.sh` separately. Prepared directories are still cleaned up.

This shortens the loop when a change only affects one target's lockfiles (for example a dependency override that only needs the sagemaker lock regenerated).

## Testing
- `bash -n` passes.
- `./scripts/update-package-locks.sh --target bogus-target` exits 1 immediately with the list of valid targets.
- Sandbox run with stubbed `prepare-src.sh`, `npm`, and `generate-oss-attribution.sh` verified all four paths:
  - one `--target`: target processed, attribution skipped with the note, prepared dirs cleaned up;
  - two `--target` flags: attribution skipped;
  - all four targets passed via flags: attribution runs;
  - no arguments: identical to previous behavior (all targets, attribution runs).

## Screenshots/Videos


## Additional Notes


## Backporting
Not needed; developer tooling only.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
